### PR TITLE
Load vis module and create hosting windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(visdriver
         src/vis_plugin.c
         src/visualization.c
         tools/generate_verification_data.cpp
+        tools/vis_host.cpp
         src/thirdparty/argparse/argparse.c
         src/thirdparty/kissfft/kiss_fft.c
         src/thirdparty/kissfft/kiss_fftr.c

--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -7,7 +7,119 @@
 #include <string>
 #include <vector>
 
+#include <windows.h>
+
+#include "vis_host.hpp"
+
 namespace {
+
+constexpr wchar_t kParentWindowClassName[] = L"visdriver.avs.parent";
+constexpr wchar_t kChildWindowClassName[] = L"visdriver.avs.child";
+
+std::wstring FormatWindowsErrorMessage(DWORD error_code) {
+  wchar_t *buffer = nullptr;
+  const DWORD flags =
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+      FORMAT_MESSAGE_IGNORE_INSERTS;
+  const DWORD size =
+      FormatMessageW(flags, nullptr, error_code,
+                     MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                     reinterpret_cast<wchar_t *>(&buffer), 0, nullptr);
+  std::wstring message;
+  if (size != 0 && buffer != nullptr) {
+    message.assign(buffer, size);
+    while (!message.empty() &&
+           (message.back() == L'\r' || message.back() == L'\n')) {
+      message.pop_back();
+    }
+  } else {
+    message = L"Unknown error";
+  }
+  if (buffer != nullptr) {
+    LocalFree(buffer);
+  }
+  return message;
+}
+
+LRESULT CALLBACK DummyWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+  return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+bool RegisterWindowClass(const wchar_t *class_name) {
+  HINSTANCE instance = GetModuleHandleW(nullptr);
+
+  WNDCLASSEXW cls{};
+  cls.cbSize = sizeof(cls);
+  cls.style = CS_HREDRAW | CS_VREDRAW;
+  cls.lpfnWndProc = DummyWindowProc;
+  cls.hInstance = instance;
+  cls.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+  cls.lpszClassName = class_name;
+
+  const ATOM atom = RegisterClassExW(&cls);
+  if (atom != 0) {
+    return true;
+  }
+
+  const DWORD error = GetLastError();
+  if (error == ERROR_CLASS_ALREADY_EXISTS) {
+    return true;
+  }
+
+  std::wcerr << L"ERROR: Failed to register window class '" << class_name
+             << L"': " << FormatWindowsErrorMessage(error) << L"\n";
+  return false;
+}
+
+HWND CreateHiddenParentWindow(int width, int height) {
+  if (!RegisterWindowClass(kParentWindowClassName)) {
+    return nullptr;
+  }
+
+  HINSTANCE instance = GetModuleHandleW(nullptr);
+
+  RECT rect{0, 0, width, height};
+  if (!AdjustWindowRectEx(&rect, WS_OVERLAPPEDWINDOW, FALSE, WS_EX_TOOLWINDOW)) {
+    const DWORD error = GetLastError();
+    std::wcerr << L"ERROR: AdjustWindowRectEx failed: "
+               << FormatWindowsErrorMessage(error) << L"\n";
+    return nullptr;
+  }
+
+  const int window_width = rect.right - rect.left;
+  const int window_height = rect.bottom - rect.top;
+
+  HWND hwnd = CreateWindowExW(WS_EX_TOOLWINDOW, kParentWindowClassName,
+                              L"visdriver avs parent", WS_OVERLAPPEDWINDOW,
+                              CW_USEDEFAULT, CW_USEDEFAULT, window_width,
+                              window_height, nullptr, nullptr, instance,
+                              nullptr);
+  if (hwnd == nullptr) {
+    const DWORD error = GetLastError();
+    std::wcerr << L"ERROR: Failed to create parent window: "
+               << FormatWindowsErrorMessage(error) << L"\n";
+  }
+  return hwnd;
+}
+
+HWND CreateChildWindow(HWND parent, int width, int height) {
+  if (!RegisterWindowClass(kChildWindowClassName)) {
+    return nullptr;
+  }
+
+  HINSTANCE instance = GetModuleHandleW(nullptr);
+  HWND hwnd = CreateWindowExW(0, kChildWindowClassName, L"visdriver avs child",
+                              WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS |
+                                  WS_VISIBLE,
+                              0, 0, width, height, parent, nullptr, instance,
+                              nullptr);
+  if (hwnd == nullptr) {
+    const DWORD error = GetLastError();
+    std::wcerr << L"ERROR: Failed to create child window: "
+               << FormatWindowsErrorMessage(error) << L"\n";
+  }
+  return hwnd;
+}
 
 enum class HashMode {
   kPixels,
@@ -210,6 +322,44 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
   }
 
   PrintSummary(options);
+
+  if (!SetCurrentDirectoryW(options.runtime_dir.c_str())) {
+    const DWORD error = GetLastError();
+    std::wcerr << L"ERROR: Failed to set current directory to '"
+               << options.runtime_dir << L"': "
+               << FormatWindowsErrorMessage(error) << L"\n";
+    return 1;
+  }
+
+  HWND parent_window = CreateHiddenParentWindow(options.width, options.height);
+  if (parent_window == nullptr) {
+    return 1;
+  }
+
+  VisHost host = load_vis(options.vis_dll, parent_window);
+  if (host.dll == nullptr || host.hdr == nullptr || host.mod == nullptr) {
+    unload_vis(host);
+    return 1;
+  }
+
+  host.child = CreateChildWindow(parent_window, options.width, options.height);
+  if (host.child == nullptr) {
+    unload_vis(host);
+    return 1;
+  }
+
+  host.mod->hwndParent = host.child;
+  host.mod->hDllInstance = host.dll;
+  host.mod->sRate = 44100;
+  host.mod->nCh = 2;
+  host.mod->latencyMs = 0;
+  host.mod->delayMs = (options.fps > 0) ? (1000 / options.fps) : 0;
+  host.mod->spectrumNch = 2;
+  host.mod->waveformNch = 2;
+
+  std::wcout << L"loaded vis module\n";
+
+  unload_vis(host);
 
   return 0;
 }

--- a/tools/vis_host.cpp
+++ b/tools/vis_host.cpp
@@ -1,0 +1,103 @@
+#include "vis_host.hpp"
+
+#include <iostream>
+
+namespace {
+
+std::wstring FormatWindowsErrorMessage(DWORD error_code) {
+  wchar_t *buffer = nullptr;
+  const DWORD flags =
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+      FORMAT_MESSAGE_IGNORE_INSERTS;
+  const DWORD size =
+      FormatMessageW(flags, nullptr, error_code,
+                     MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                     reinterpret_cast<wchar_t *>(&buffer), 0, nullptr);
+  std::wstring message;
+  if (size != 0 && buffer != nullptr) {
+    message.assign(buffer, size);
+    while (!message.empty() &&
+           (message.back() == L'\r' || message.back() == L'\n')) {
+      message.pop_back();
+    }
+  } else {
+    message = L"Unknown error";
+  }
+  if (buffer != nullptr) {
+    LocalFree(buffer);
+  }
+  return message;
+}
+
+} // namespace
+
+VisHost load_vis(const std::wstring &dll_path, HWND parent) {
+  VisHost host;
+  host.parent = parent;
+
+  host.dll = LoadLibraryW(dll_path.c_str());
+  if (host.dll == nullptr) {
+    const DWORD error = GetLastError();
+    std::wcerr << L"ERROR: Failed to load vis DLL '" << dll_path
+               << L"': " << FormatWindowsErrorMessage(error) << L"\n";
+    return host;
+  }
+
+  FARPROC proc = GetProcAddress(host.dll, "winampVisGetHeader");
+  if (proc == nullptr) {
+    std::wcerr << L"ERROR: Symbol 'winampVisGetHeader' not found in '" << dll_path
+               << L"'.\n";
+    FreeLibrary(host.dll);
+    host.dll = nullptr;
+    return host;
+  }
+
+  auto get_header = reinterpret_cast<winampVisGetHeaderType>(proc);
+  winampVisHeader *const header = get_header();
+  if (header == nullptr) {
+    std::wcerr << L"ERROR: winampVisGetHeader returned null for '" << dll_path
+               << L"'.\n";
+    FreeLibrary(host.dll);
+    host.dll = nullptr;
+    return host;
+  }
+
+  if (header->getModule == nullptr) {
+    std::wcerr << L"ERROR: winampVisHeader::getModule is null in '" << dll_path
+               << L"'.\n";
+    FreeLibrary(host.dll);
+    host.dll = nullptr;
+    return host;
+  }
+
+  winampVisModule *const module = header->getModule(0);
+  if (module == nullptr) {
+    std::wcerr << L"ERROR: Failed to fetch first vis module from '" << dll_path
+               << L"'.\n";
+    FreeLibrary(host.dll);
+    host.dll = nullptr;
+    return host;
+  }
+
+  host.hdr = header;
+  host.mod = module;
+
+  return host;
+}
+
+void unload_vis(VisHost &host) {
+  if (host.child != nullptr) {
+    DestroyWindow(host.child);
+    host.child = nullptr;
+  }
+  if (host.parent != nullptr) {
+    DestroyWindow(host.parent);
+    host.parent = nullptr;
+  }
+  host.hdr = nullptr;
+  host.mod = nullptr;
+  if (host.dll != nullptr) {
+    FreeLibrary(host.dll);
+    host.dll = nullptr;
+  }
+}

--- a/tools/vis_host.hpp
+++ b/tools/vis_host.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+#include <windows.h>
+
+#include <winamp/vis.h>
+
+struct VisHost {
+  HMODULE dll = nullptr;
+  winampVisHeader *hdr = nullptr;
+  winampVisModule *mod = nullptr;
+  HWND parent = nullptr;
+  HWND child = nullptr;
+};
+
+VisHost load_vis(const std::wstring &dll_path, HWND parent);
+
+void unload_vis(VisHost &host);


### PR DESCRIPTION
## Summary
- add a vis_host helper that loads a Winamp visualization DLL and exposes the first module
- create hidden parent/child windows for the visualization module in generate-verification-data and configure module fields
- set the runtime directory before loading the DLL and clean up windows and the library on exit

## Testing
- not run (Windows-only build)

------
https://chatgpt.com/codex/tasks/task_e_68d2904418e0832ca154a609b5fc1c98