### PR TITLE
Fix LoadCursorW call for wide-char API

### DIFF
--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -53,7 +53,7 @@ bool RegisterWindowClass(const wchar_t *class_name) {
   cls.style = CS_HREDRAW | CS_VREDRAW;
   cls.lpfnWndProc = DummyWindowProc;
   cls.hInstance = instance;
-  cls.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+  cls.hCursor = LoadCursorW(nullptr, MAKEINTRESOURCEW(IDC_ARROW));
   cls.lpszClassName = class_name;
 
   const ATOM atom = RegisterClassExW(&cls);


### PR DESCRIPTION
## Summary
- fix LoadCursorW to use MAKEINTRESOURCEW when registering window classes

## Testing
- cmake -S . -B build

------
https://chatgpt.com/codex/tasks/task_e_68d2941ff028832c8c5292f9786460c2