### PR TITLE
Fix cursor resource cast for MinGW

### DIFF
--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -53,7 +53,7 @@ bool RegisterWindowClass(const wchar_t *class_name) {
   cls.style = CS_HREDRAW | CS_VREDRAW;
   cls.lpfnWndProc = DummyWindowProc;
   cls.hInstance = instance;
-  cls.hCursor = LoadCursorW(nullptr, MAKEINTRESOURCEW(IDC_ARROW));
+  cls.hCursor = LoadCursorW(nullptr, reinterpret_cast<LPCWSTR>(IDC_ARROW));
   cls.lpszClassName = class_name;
 
   const ATOM atom = RegisterClassExW(&cls);


### PR DESCRIPTION
## Summary
- fix the cursor registration to avoid narrowing the IDC_ARROW resource when building with MinGW

## Testing
- cmake -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build
- make -C build -j$(nproc) VERBOSE=1

------
https://chatgpt.com/codex/tasks/task_e_68d295207d3c832cafdcceec1afe7c73