### PR TITLE
Implement dry render loop for verification data

### DIFF
--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include <xmmintrin.h>
+
 #include <windows.h>
 
 #include "vis_host.hpp"
@@ -386,16 +388,39 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     return 1;
   }
 
-  host.mod->hwndParent = host.child;
-  host.mod->hDllInstance = host.dll;
-  host.mod->sRate = 44100;
-  host.mod->nCh = 2;
-  host.mod->latencyMs = 0;
   host.mod->delayMs = (options.fps > 0) ? (1000 / options.fps) : 0;
-  host.mod->spectrumNch = 2;
-  host.mod->waveformNch = 2;
+  if (!begin_vis(host, options.width, options.height)) {
+    unload_vis(host);
+    return 1;
+  }
+
+  if (host.mod->Render == nullptr) {
+    std::wcerr << L"ERROR: Visualization module is missing Render().\n";
+    end_vis(host);
+    unload_vis(host);
+    return 1;
+  }
 
   std::wcout << L"loaded vis module\n";
+
+#if defined(_MM_SET_FLUSH_ZERO_MODE) && defined(_MM_SET_DENORMALS_ZERO_MODE)
+  _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+  _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+#endif
+
+  for (int frame = 0; frame < options.frames; ++frame) {
+    for (int channel = 0; channel < 2; ++channel) {
+      std::fill_n(host.mod->waveformData[channel], 576, 128);
+      std::fill_n(host.mod->spectrumData[channel], 576, 0);
+    }
+
+    const int render_result = host.mod->Render(host.mod);
+    if (render_result != 0) {
+      break;
+    }
+  }
+
+  end_vis(host);
 
   unload_vis(host);
 

--- a/tools/vis_host.cpp
+++ b/tools/vis_host.cpp
@@ -101,3 +101,49 @@ void unload_vis(VisHost &host) {
     host.dll = nullptr;
   }
 }
+
+bool begin_vis(VisHost &host, int width, int height) {
+  if (host.mod == nullptr) {
+    std::wcerr << L"ERROR: Visualization module handle is null.\n";
+    return false;
+  }
+
+  HWND const target_window = (host.child != nullptr) ? host.child : host.parent;
+  host.mod->hwndParent = target_window;
+  host.mod->hDllInstance = host.dll;
+  host.mod->sRate = 44100;
+  host.mod->nCh = 2;
+  host.mod->latencyMs = 0;
+  host.mod->spectrumNch = 2;
+  host.mod->waveformNch = 2;
+
+  if (target_window != nullptr) {
+    SetWindowPos(target_window, nullptr, 0, 0, width, height,
+                 SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOMOVE);
+  }
+
+  if (host.mod->Init == nullptr) {
+    std::wcerr << L"ERROR: Visualization module is missing Init().\n";
+    return false;
+  }
+
+  const int init_result = host.mod->Init(host.mod);
+  if (init_result != 0) {
+    std::wcerr << L"ERROR: Visualization module Init() returned "
+               << init_result << L".\n";
+    return false;
+  }
+
+  return true;
+}
+
+void end_vis(VisHost &host) {
+  if (host.mod != nullptr && host.mod->Quit != nullptr) {
+    host.mod->Quit(host.mod);
+  }
+
+  if (host.child != nullptr) {
+    DestroyWindow(host.child);
+    host.child = nullptr;
+  }
+}

--- a/tools/vis_host.hpp
+++ b/tools/vis_host.hpp
@@ -17,3 +17,7 @@ struct VisHost {
 VisHost load_vis(const std::wstring &dll_path, HWND parent);
 
 void unload_vis(VisHost &host);
+
+bool begin_vis(VisHost &host, int width, int height);
+
+void end_vis(VisHost &host);


### PR DESCRIPTION
## Summary
- add begin_vis/end_vis helpers to manage Winamp visualization modules
- initialize and render visualization frames with zeroed buffers in generate-verification-data
- enable SSE flush-to-zero/denormals-are-zero handling before the render loop

## Testing
- not run (Windows-specific binaries)


------
https://chatgpt.com/codex/tasks/task_e_68d2a275c414832cb5cb0d6d68e8cedf