### PR TITLE
Add pixel hashing outputs to verification command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(visdriver
         src/visualization.c
         tools/capture.cpp
         tools/generate_verification_data.cpp
+        tools/sha256.cpp
         tools/spectrum.cpp
         tools/wav_reader.cpp
         tools/vis_host.cpp

--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cwchar>
@@ -7,11 +8,14 @@
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
+#include <limits>
+#include <memory>
 #include <stdexcept>
 #include <sstream>
 #include <string>
-#include <vector>
 #include <system_error>
+#include <type_traits>
+#include <vector>
 
 #include <xmmintrin.h>
 
@@ -19,6 +23,7 @@
 
 #include "capture.hpp"
 #include "spectrum.hpp"
+#include "sha256.hpp"
 #include "vis_host.hpp"
 #include "wav_reader.hpp"
 
@@ -30,6 +35,43 @@ constexpr int kWaveformSamples = 576;
 constexpr int kSpectrumFftSize = 1024;
 
 int g_total_pcm_samples = 0;
+
+struct HandleCloser {
+  void operator()(HANDLE handle) const {
+    if (handle != nullptr && handle != INVALID_HANDLE_VALUE) {
+      CloseHandle(handle);
+    }
+  }
+};
+
+using ScopedHandle =
+    std::unique_ptr<std::remove_pointer<HANDLE>::type, HandleCloser>;
+
+bool WriteAllBytes(HANDLE handle, const std::string &text) {
+  if (handle == nullptr || handle == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+  if (text.empty()) {
+    return true;
+  }
+
+  const char *data = text.data();
+  size_t remaining = text.size();
+  while (remaining > 0) {
+    const DWORD chunk = static_cast<DWORD>(
+        std::min<size_t>(remaining, std::numeric_limits<DWORD>::max()));
+    DWORD written = 0;
+    if (!WriteFile(handle, data, chunk, &written, nullptr)) {
+      return false;
+    }
+    if (written == 0) {
+      return false;
+    }
+    data += written;
+    remaining -= written;
+  }
+  return true;
+}
 
 std::wstring ConvertToWide(const std::string &text) {
   if (text.empty()) {
@@ -459,11 +501,31 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     return 1;
   }
   const std::filesystem::path frames_dir_path = out_dir_path / L"frames";
+  const std::filesystem::path hashes_dir_path = out_dir_path / L"hashes";
 
   if (!EnsureDirectoryExists(out_dir_path.wstring())) {
     return 1;
   }
   if (!EnsureDirectoryExists(frames_dir_path.wstring())) {
+    return 1;
+  }
+  if (!EnsureDirectoryExists(hashes_dir_path.wstring())) {
+    return 1;
+  }
+
+  const std::filesystem::path per_frame_csv_path =
+      hashes_dir_path / L"per_frame.csv";
+  const std::filesystem::path rolling_hash_path =
+      hashes_dir_path / L"rolling_sha256.txt";
+
+  ScopedHandle per_frame_file(CreateFileW(
+      per_frame_csv_path.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr,
+      CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+  if (!per_frame_file || per_frame_file.get() == INVALID_HANDLE_VALUE) {
+    const DWORD error = GetLastError();
+    std::wcerr << L"ERROR: Failed to open per-frame hash file '"
+               << per_frame_csv_path.wstring() << L"': "
+               << FormatWindowsErrorMessage(error) << L"\n";
     return 1;
   }
 
@@ -540,6 +602,8 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
 
   std::vector<uint8_t> frame_rgba;
   bool capture_failed = false;
+  bool hash_failed = false;
+  Sha256 rolling_hash;
 
   for (int frame = 0; frame < options.frames; ++frame) {
     const int fps_value = (options.fps > 0) ? options.fps : 1;
@@ -585,6 +649,17 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
       break;
     }
 
+    const std::array<uint8_t, 32> frame_digest = Sha256Hash(frame_rgba);
+    const std::string frame_hex = Sha256ToHex(frame_digest);
+    const std::string csv_line = std::to_string(frame) + "," + frame_hex + "\n";
+    if (!WriteAllBytes(per_frame_file.get(), csv_line)) {
+      std::wcerr << L"ERROR: Failed to write per-frame hash for frame " << frame
+                 << L".\n";
+      hash_failed = true;
+      break;
+    }
+    rolling_hash.Update(frame_rgba);
+
     if ((frame % options.png_step) == 0) {
       const std::filesystem::path png_path =
           frames_dir_path / FormatFrameFilename(frame);
@@ -597,11 +672,47 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     }
   }
 
+  if (!capture_failed && !hash_failed) {
+    if (!FlushFileBuffers(per_frame_file.get())) {
+      const DWORD error = GetLastError();
+      std::wcerr << L"ERROR: Failed to flush per-frame hash file: "
+                 << FormatWindowsErrorMessage(error) << L"\n";
+      hash_failed = true;
+    }
+  }
+
   end_vis(host);
 
   unload_vis(host);
 
-  if (capture_failed) {
+  if (!capture_failed && !hash_failed) {
+    const std::array<uint8_t, 32> rolling_digest = rolling_hash.Final();
+    const std::string rolling_hex = Sha256ToHex(rolling_digest);
+    const std::string rolling_line = rolling_hex + "\n";
+
+    ScopedHandle rolling_file(CreateFileW(
+        rolling_hash_path.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!rolling_file || rolling_file.get() == INVALID_HANDLE_VALUE) {
+      const DWORD error = GetLastError();
+      std::wcerr << L"ERROR: Failed to open rolling hash file '"
+                 << rolling_hash_path.wstring() << L"': "
+                 << FormatWindowsErrorMessage(error) << L"\n";
+      hash_failed = true;
+    } else {
+      if (!WriteAllBytes(rolling_file.get(), rolling_line)) {
+        std::wcerr << L"ERROR: Failed to write rolling hash.\n";
+        hash_failed = true;
+      } else if (!FlushFileBuffers(rolling_file.get())) {
+        const DWORD error = GetLastError();
+        std::wcerr << L"ERROR: Failed to flush rolling hash file: "
+                   << FormatWindowsErrorMessage(error) << L"\n";
+        hash_failed = true;
+      }
+    }
+  }
+
+  if (capture_failed || hash_failed) {
     return 1;
   }
 

--- a/tools/sha256.cpp
+++ b/tools/sha256.cpp
@@ -1,0 +1,210 @@
+#include "sha256.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <stdexcept>
+
+namespace {
+
+constexpr uint32_t kSha256InitState[8] = {
+    0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+    0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u,
+};
+
+constexpr uint32_t kSha256K[64] = {
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu,
+    0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u, 0xd807aa98u, 0x12835b01u,
+    0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u,
+    0xc19bf174u, 0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu,
+    0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau, 0x983e5152u,
+    0xa831c66du, 0xb00327c8u, 0xbf597fc7u, 0xc6e00bf3u, 0xd5a79147u,
+    0x06ca6351u, 0x14292967u, 0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu,
+    0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+    0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u, 0xd192e819u,
+    0xd6990624u, 0xf40e3585u, 0x106aa070u, 0x19a4c116u, 0x1e376c08u,
+    0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu,
+    0x682e6ff3u, 0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
+    0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u,
+};
+
+inline uint32_t RotateRight(uint32_t value, uint32_t bits) {
+  return (value >> bits) | (value << (32 - bits));
+}
+
+inline uint32_t Sigma0(uint32_t x) {
+  return RotateRight(x, 7) ^ RotateRight(x, 18) ^ (x >> 3);
+}
+
+inline uint32_t Sigma1(uint32_t x) {
+  return RotateRight(x, 17) ^ RotateRight(x, 19) ^ (x >> 10);
+}
+
+inline uint32_t BigSigma0(uint32_t x) {
+  return RotateRight(x, 2) ^ RotateRight(x, 13) ^ RotateRight(x, 22);
+}
+
+inline uint32_t BigSigma1(uint32_t x) {
+  return RotateRight(x, 6) ^ RotateRight(x, 11) ^ RotateRight(x, 25);
+}
+
+inline uint32_t Ch(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) ^ ((~x) & z);
+}
+
+inline uint32_t Maj(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+}  // namespace
+
+Sha256::Sha256()
+    : finalized_(false), bit_count_(0), state_(), buffer_(), buffer_size_(0),
+      final_digest_() {
+  std::copy(std::begin(kSha256InitState), std::end(kSha256InitState),
+            state_.begin());
+}
+
+void Sha256::Update(const uint8_t *data, size_t len) {
+  if (finalized_) {
+    throw std::logic_error("Cannot update SHA-256 after finalization");
+  }
+  if (data == nullptr) {
+    if (len == 0) {
+      return;
+    }
+    throw std::invalid_argument("SHA-256 update data pointer is null");
+  }
+
+  bit_count_ += static_cast<uint64_t>(len) * 8;
+
+  size_t offset = 0;
+  while (len > 0) {
+    const size_t space = 64 - buffer_size_;
+    const size_t to_copy = std::min(space, len);
+    std::memcpy(buffer_.data() + buffer_size_, data + offset, to_copy);
+    buffer_size_ += to_copy;
+    offset += to_copy;
+    len -= to_copy;
+
+    if (buffer_size_ == 64) {
+      Transform(buffer_.data());
+      buffer_size_ = 0;
+    }
+  }
+}
+
+void Sha256::Update(const std::vector<uint8_t> &data) {
+  if (!data.empty()) {
+    Update(data.data(), data.size());
+  }
+}
+
+std::array<uint8_t, 32> Sha256::Final() {
+  if (!finalized_) {
+    buffer_[buffer_size_] = 0x80;
+    ++buffer_size_;
+
+    if (buffer_size_ > 56) {
+      std::fill(buffer_.begin() + buffer_size_, buffer_.end(), 0);
+      Transform(buffer_.data());
+      buffer_size_ = 0;
+    }
+
+    std::fill(buffer_.begin() + buffer_size_, buffer_.begin() + 56, 0);
+
+    for (int i = 0; i < 8; ++i) {
+      buffer_[56 + i] =
+          static_cast<uint8_t>((bit_count_ >> (8 * (7 - i))) & 0xffu);
+    }
+
+    Transform(buffer_.data());
+    buffer_size_ = 0;
+
+    for (size_t i = 0; i < state_.size(); ++i) {
+      final_digest_[i * 4 + 0] = static_cast<uint8_t>((state_[i] >> 24) & 0xffu);
+      final_digest_[i * 4 + 1] = static_cast<uint8_t>((state_[i] >> 16) & 0xffu);
+      final_digest_[i * 4 + 2] = static_cast<uint8_t>((state_[i] >> 8) & 0xffu);
+      final_digest_[i * 4 + 3] = static_cast<uint8_t>(state_[i] & 0xffu);
+    }
+
+    finalized_ = true;
+  }
+
+  return final_digest_;
+}
+
+void Sha256::Transform(const uint8_t block[64]) {
+  uint32_t w[64];
+  for (int i = 0; i < 16; ++i) {
+    w[i] = (static_cast<uint32_t>(block[i * 4 + 0]) << 24) |
+           (static_cast<uint32_t>(block[i * 4 + 1]) << 16) |
+           (static_cast<uint32_t>(block[i * 4 + 2]) << 8) |
+           (static_cast<uint32_t>(block[i * 4 + 3]));
+  }
+  for (int i = 16; i < 64; ++i) {
+    w[i] = Sigma1(w[i - 2]) + w[i - 7] + Sigma0(w[i - 15]) + w[i - 16];
+  }
+
+  uint32_t a = state_[0];
+  uint32_t b = state_[1];
+  uint32_t c = state_[2];
+  uint32_t d = state_[3];
+  uint32_t e = state_[4];
+  uint32_t f = state_[5];
+  uint32_t g = state_[6];
+  uint32_t h = state_[7];
+
+  for (int i = 0; i < 64; ++i) {
+    const uint32_t temp1 = h + BigSigma1(e) + Ch(e, f, g) + kSha256K[i] + w[i];
+    const uint32_t temp2 = BigSigma0(a) + Maj(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = d + temp1;
+    d = c;
+    c = b;
+    b = a;
+    a = temp1 + temp2;
+  }
+
+  state_[0] += a;
+  state_[1] += b;
+  state_[2] += c;
+  state_[3] += d;
+  state_[4] += e;
+  state_[5] += f;
+  state_[6] += g;
+  state_[7] += h;
+}
+
+std::array<uint8_t, 32> Sha256Hash(const uint8_t *data, size_t len) {
+  Sha256 ctx;
+  if (len > 0) {
+    ctx.Update(data, len);
+  }
+  return ctx.Final();
+}
+
+std::array<uint8_t, 32> Sha256Hash(const std::vector<uint8_t> &data) {
+  Sha256 ctx;
+  if (!data.empty()) {
+    ctx.Update(data.data(), data.size());
+  }
+  return ctx.Final();
+}
+
+std::string Sha256ToHex(const std::array<uint8_t, 32> &digest) {
+  return Sha256ToHex(digest.data());
+}
+
+std::string Sha256ToHex(const uint8_t digest[32]) {
+  static const char kHexDigits[] = "0123456789abcdef";
+  std::string result(64, '0');
+  for (size_t i = 0; i < 32; ++i) {
+    result[i * 2] = kHexDigits[(digest[i] >> 4) & 0x0fu];
+    result[i * 2 + 1] = kHexDigits[digest[i] & 0x0fu];
+  }
+  return result;
+}
+

--- a/tools/sha256.hpp
+++ b/tools/sha256.hpp
@@ -1,0 +1,35 @@
+#ifndef TOOLS_SHA256_HPP_
+#define TOOLS_SHA256_HPP_
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class Sha256 {
+ public:
+  Sha256();
+
+  void Update(const uint8_t *data, size_t len);
+  void Update(const std::vector<uint8_t> &data);
+
+  std::array<uint8_t, 32> Final();
+
+ private:
+  void Transform(const uint8_t block[64]);
+
+  bool finalized_;
+  uint64_t bit_count_;
+  std::array<uint32_t, 8> state_;
+  std::array<uint8_t, 64> buffer_;
+  size_t buffer_size_;
+  std::array<uint8_t, 32> final_digest_;
+};
+
+std::array<uint8_t, 32> Sha256Hash(const uint8_t *data, size_t len);
+std::array<uint8_t, 32> Sha256Hash(const std::vector<uint8_t> &data);
+std::string Sha256ToHex(const std::array<uint8_t, 32> &digest);
+std::string Sha256ToHex(const uint8_t digest[32]);
+
+#endif  // TOOLS_SHA256_HPP_


### PR DESCRIPTION
## Summary
- add a self-contained SHA-256 helper to compute frame hashes
- record per-frame RGBA hashes and a rolling digest when generating verification data
- ensure the hashes directory is created and included in the build

## Testing
- not run (Windows/MSVC build environment required)


------
https://chatgpt.com/codex/tasks/task_e_68d2ad2edf18832c9478bef6daa31c87