### PR TITLE
Add manifest generation and AVI output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,10 @@ add_executable(visdriver
         src/output_plugin.c
         src/vis_plugin.c
         src/visualization.c
+        tools/avi_writer.cpp
         tools/capture.cpp
         tools/generate_verification_data.cpp
+        tools/manifest.cpp
         tools/sha256.cpp
         tools/spectrum.cpp
         tools/wav_reader.cpp
@@ -73,3 +75,11 @@ if (IS_DIRECTORY "${CMAKE_SOURCE_DIR}/.git")
     string(STRIP "${PROJECT_GIT_SHA1}" PROJECT_GIT_SHA1)
 endif()
 target_compile_definitions(visdriver PRIVATE PROJECT_VERSION="${PROJECT_VERSION}" PROJECT_GIT_SHA1="${PROJECT_GIT_SHA1}")
+
+if (MSVC)
+    set(VFW32_LIB Vfw32)
+else ()
+    set(VFW32_LIB vfw32)
+endif ()
+
+target_link_libraries(visdriver PRIVATE ${VFW32_LIB})

--- a/tools/avi_writer.cpp
+++ b/tools/avi_writer.cpp
@@ -1,0 +1,141 @@
+#include "avi_writer.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+
+AviWriter::AviWriter() {
+  AVIFileInit();
+}
+
+AviWriter::~AviWriter() {
+  Close();
+  AVIFileExit();
+}
+
+bool AviWriter::IsOpen() const {
+  return stream_ != nullptr;
+}
+
+bool AviWriter::Open(const std::wstring &path, int width, int height, int fps) {
+  Close();
+
+  if (path.empty() || width <= 0 || height <= 0 || fps <= 0) {
+    std::wcerr << L"ERROR: Invalid parameters when opening AVI writer.\n";
+    return false;
+  }
+
+  width_ = width;
+  height_ = height;
+  fps_ = fps;
+  frame_index_ = 0;
+
+  HRESULT hr = AVIFileOpenW(&avi_file_, path.c_str(), OF_WRITE | OF_CREATE, nullptr);
+  if (FAILED(hr) || avi_file_ == nullptr) {
+    std::wcerr << L"ERROR: AVIFileOpenW failed for '" << path
+               << L"' (HRESULT 0x" << std::hex << hr << std::dec << L").\n";
+    avi_file_ = nullptr;
+    return false;
+  }
+
+  AVISTREAMINFO info;
+  std::memset(&info, 0, sizeof(info));
+  info.fccType = streamtypeVIDEO;
+  info.dwScale = 1;
+  info.dwRate = static_cast<DWORD>(fps_);
+  info.dwSuggestedBufferSize = static_cast<DWORD>(width_ * height_ * 4);
+  info.rcFrame.right = static_cast<LONG>(width_);
+  info.rcFrame.bottom = static_cast<LONG>(height_);
+
+  hr = AVIFileCreateStreamW(avi_file_, &stream_, &info);
+  if (FAILED(hr) || stream_ == nullptr) {
+    std::wcerr << L"ERROR: AVIFileCreateStreamW failed (HRESULT 0x" << std::hex << hr
+               << std::dec << L").\n";
+    Close();
+    return false;
+  }
+
+  if (!SetStreamFormat()) {
+    Close();
+    return false;
+  }
+
+  return true;
+}
+
+bool AviWriter::SetStreamFormat() {
+  if (stream_ == nullptr) {
+    return false;
+  }
+
+  BITMAPINFOHEADER bih;
+  std::memset(&bih, 0, sizeof(bih));
+  bih.biSize = sizeof(BITMAPINFOHEADER);
+  bih.biWidth = width_;
+  bih.biHeight = -height_;
+  bih.biPlanes = 1;
+  bih.biBitCount = 32;
+  bih.biCompression = BI_RGB;
+  bih.biSizeImage = static_cast<DWORD>(width_ * height_ * 4);
+
+  HRESULT hr = AVIStreamSetFormat(stream_, 0, &bih, sizeof(bih));
+  if (FAILED(hr)) {
+    std::wcerr << L"ERROR: AVIStreamSetFormat failed (HRESULT 0x" << std::hex << hr
+               << std::dec << L").\n";
+    return false;
+  }
+
+  return true;
+}
+
+bool AviWriter::WriteFrame(const uint8_t *rgba, size_t byte_count) {
+  if (!IsOpen()) {
+    std::wcerr << L"ERROR: AVI writer is not open.\n";
+    return false;
+  }
+
+  const size_t expected_bytes = static_cast<size_t>(width_) *
+                                static_cast<size_t>(height_) * 4;
+  if (rgba == nullptr || byte_count != expected_bytes) {
+    std::wcerr << L"ERROR: Invalid frame data for AVI writer.\n";
+    return false;
+  }
+
+  scratch_.resize(expected_bytes);
+  const uint8_t *src = rgba;
+  uint8_t *dst = scratch_.data();
+  for (size_t i = 0; i < expected_bytes; i += 4) {
+    dst[i + 0] = src[i + 2];
+    dst[i + 1] = src[i + 1];
+    dst[i + 2] = src[i + 0];
+    dst[i + 3] = src[i + 3];
+  }
+
+  HRESULT hr = AVIStreamWrite(stream_, frame_index_, 1, scratch_.data(),
+                              static_cast<LONG>(expected_bytes), 0, nullptr,
+                              nullptr);
+  if (FAILED(hr)) {
+    std::wcerr << L"ERROR: AVIStreamWrite failed on frame " << frame_index_
+               << L" (HRESULT 0x" << std::hex << hr << std::dec << L").\n";
+    return false;
+  }
+
+  ++frame_index_;
+  return true;
+}
+
+void AviWriter::Close() {
+  if (stream_ != nullptr) {
+    AVIStreamRelease(stream_);
+    stream_ = nullptr;
+  }
+  if (avi_file_ != nullptr) {
+    AVIFileRelease(avi_file_);
+    avi_file_ = nullptr;
+  }
+  scratch_.clear();
+  width_ = 0;
+  height_ = 0;
+  fps_ = 0;
+  frame_index_ = 0;
+}

--- a/tools/avi_writer.hpp
+++ b/tools/avi_writer.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <windows.h>
+#include <vfw.h>
+
+class AviWriter {
+ public:
+  AviWriter();
+  ~AviWriter();
+
+  bool Open(const std::wstring &path, int width, int height, int fps);
+  bool WriteFrame(const uint8_t *rgba, size_t byte_count);
+  void Close();
+  bool IsOpen() const;
+
+ private:
+  bool SetStreamFormat();
+
+  PAVIFILE avi_file_ = nullptr;
+  PAVISTREAM stream_ = nullptr;
+  int width_ = 0;
+  int height_ = 0;
+  int fps_ = 0;
+  int frame_index_ = 0;
+  std::vector<uint8_t> scratch_;
+};

--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -21,7 +21,9 @@
 
 #include <windows.h>
 
+#include "avi_writer.hpp"
 #include "capture.hpp"
+#include "manifest.hpp"
 #include "spectrum.hpp"
 #include "sha256.hpp"
 #include "vis_host.hpp"
@@ -530,6 +532,9 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
   }
 
   std::vector<int16_t> audio_pcm;
+  int wav_sample_rate = 0;
+  int wav_channels = 0;
+  int64_t wav_sample_count = 0;
   try {
     WavData wav = load_wav_16le_stereo(options.wav);
     if (wav.channels != 2) {
@@ -545,6 +550,9 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     const size_t total_samples = audio_pcm.size() / 2;
     std::wcout << L"WAV ok: 44100 Hz, 2 ch, " << total_samples << L" samples\n";
     g_total_pcm_samples = static_cast<int>(total_samples);
+    wav_sample_rate = 44100;
+    wav_channels = 2;
+    wav_sample_count = static_cast<int64_t>(total_samples);
   } catch (const std::exception &ex) {
     std::wcerr << L"ERROR: Failed to load WAV: "
                << ConvertToWide(std::string(ex.what())) << L"\n";
@@ -601,13 +609,31 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
   bool logged_spectrum_ok = false;
 
   std::vector<uint8_t> frame_rgba;
+  std::vector<std::filesystem::path> png_outputs;
   bool capture_failed = false;
   bool hash_failed = false;
+  bool avi_failed = false;
+  const int effective_fps = (options.fps > 0) ? options.fps : 1;
+  AviWriter avi_writer;
+  const bool avi_enabled = !options.avi_out.empty();
+  std::filesystem::path avi_output_path;
+  if (avi_enabled) {
+    avi_output_path = out_dir_path / options.avi_out;
+  }
+  bool avi_opened = false;
+  if (avi_enabled && options.frames == 0) {
+    if (!avi_writer.Open(avi_output_path.wstring(), options.width,
+                         options.height, effective_fps)) {
+      avi_failed = true;
+    } else {
+      avi_opened = true;
+    }
+  }
   Sha256 rolling_hash;
 
   for (int frame = 0; frame < options.frames; ++frame) {
-    const int fps_value = (options.fps > 0) ? options.fps : 1;
-    const int samples_per_frame = static_cast<int>(std::lround(44100.0 / fps_value));
+    const int samples_per_frame =
+        static_cast<int>(std::lround(44100.0 / effective_fps));
     const int hop = std::max(1, samples_per_frame / kWaveformSamples);
     const int start_sample = frame * samples_per_frame;
 
@@ -649,6 +675,21 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
       break;
     }
 
+    if (avi_enabled && !avi_failed) {
+      if (!avi_opened) {
+        if (!avi_writer.Open(avi_output_path.wstring(), options.width,
+                             options.height, effective_fps)) {
+          avi_failed = true;
+          break;
+        }
+        avi_opened = true;
+      }
+      if (!avi_writer.WriteFrame(frame_rgba.data(), frame_rgba.size())) {
+        avi_failed = true;
+        break;
+      }
+    }
+
     const std::array<uint8_t, 32> frame_digest = Sha256Hash(frame_rgba);
     const std::string frame_hex = Sha256ToHex(frame_digest);
     const std::string csv_line = std::to_string(frame) + "," + frame_hex + "\n";
@@ -668,11 +709,16 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
         capture_failed = true;
         break;
       }
+      png_outputs.push_back(png_path);
       std::wcout << L"Wrote " << png_path << L"\n";
     }
   }
 
-  if (!capture_failed && !hash_failed) {
+  if (avi_writer.IsOpen()) {
+    avi_writer.Close();
+  }
+
+  if (!capture_failed && !hash_failed && !avi_failed) {
     if (!FlushFileBuffers(per_frame_file.get())) {
       const DWORD error = GetLastError();
       std::wcerr << L"ERROR: Failed to flush per-frame hash file: "
@@ -685,7 +731,7 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
 
   unload_vis(host);
 
-  if (!capture_failed && !hash_failed) {
+  if (!capture_failed && !hash_failed && !avi_failed) {
     const std::array<uint8_t, 32> rolling_digest = rolling_hash.Final();
     const std::string rolling_hex = Sha256ToHex(rolling_digest);
     const std::string rolling_line = rolling_hex + "\n";
@@ -712,7 +758,39 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     }
   }
 
-  if (capture_failed || hash_failed) {
+  if (capture_failed || hash_failed || avi_failed) {
+    return 1;
+  }
+
+  ManifestInfo manifest;
+  manifest.out_dir = out_dir_path;
+  manifest.vis_dll_path = options.vis_dll;
+  manifest.runtime_dir = options.runtime_dir;
+  manifest.has_vis_avs_dat = !options.vis_avs_dat.empty();
+  if (manifest.has_vis_avs_dat) {
+    manifest.vis_avs_dat_path = options.vis_avs_dat;
+  }
+  manifest.has_preset = !options.preset.empty();
+  if (manifest.has_preset) {
+    manifest.preset_path = options.preset;
+  }
+  manifest.wav_path = options.wav;
+  manifest.wav_sample_rate = wav_sample_rate;
+  manifest.wav_channels = wav_channels;
+  manifest.wav_sample_count = wav_sample_count;
+  manifest.width = options.width;
+  manifest.height = options.height;
+  manifest.fps = options.fps;
+  manifest.frames = options.frames;
+  manifest.png_paths = png_outputs;
+  manifest.per_frame_hash_path = per_frame_csv_path;
+  manifest.rolling_hash_path = rolling_hash_path;
+  manifest.has_avi_output = avi_enabled && avi_opened && !avi_failed;
+  if (manifest.has_avi_output) {
+    manifest.avi_output_path = avi_output_path;
+  }
+
+  if (!WriteManifest(manifest)) {
     return 1;
   }
 

--- a/tools/manifest.cpp
+++ b/tools/manifest.cpp
@@ -1,0 +1,347 @@
+#include "manifest.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <iostream>
+#include <limits>
+#include <system_error>
+#include <vector>
+
+#include <windows.h>
+
+namespace {
+
+std::string WideToUtf8(const std::wstring &value) {
+  if (value.empty()) {
+    return std::string();
+  }
+  const int required =
+      WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, value.c_str(), -1,
+                          nullptr, 0, nullptr, nullptr);
+  if (required <= 0) {
+    return std::string("(conversion error)");
+  }
+  std::string result(static_cast<size_t>(required - 1), '\0');
+  if (!result.empty()) {
+    WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, value.c_str(), -1,
+                        result.data(), required, nullptr, nullptr);
+  }
+  return result;
+}
+
+std::string PathToUtf8(const std::filesystem::path &path) {
+  if (path.empty()) {
+    return std::string();
+  }
+  return WideToUtf8(path.generic_wstring());
+}
+
+bool HasParentTraversal(const std::filesystem::path &path) {
+  for (const auto &part : path) {
+    if (part == std::filesystem::path(L"..")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::filesystem::path MakeRelativeIfPossible(const std::filesystem::path &path,
+                                             const std::filesystem::path &base) {
+  if (path.empty() || base.empty()) {
+    return path;
+  }
+  std::error_code ec;
+  std::filesystem::path relative = std::filesystem::relative(path, base, ec);
+  if (!ec) {
+    relative = relative.lexically_normal();
+    if (!HasParentTraversal(relative)) {
+      return relative;
+    }
+  }
+  return path;
+}
+
+class JsonWriter {
+ public:
+  void BeginObject() {
+    WriteValuePrefix();
+    buffer_.push_back('{');
+    stack_.push_back({ContextType::Object, true, false});
+  }
+
+  void EndObject() {
+    if (stack_.empty() || stack_.back().type != ContextType::Object) {
+      error_ = true;
+      return;
+    }
+    if (stack_.back().expect_value) {
+      error_ = true;
+      return;
+    }
+    buffer_.push_back('}');
+    stack_.pop_back();
+  }
+
+  void BeginArray() {
+    WriteValuePrefix();
+    buffer_.push_back('[');
+    stack_.push_back({ContextType::Array, true, false});
+  }
+
+  void EndArray() {
+    if (stack_.empty() || stack_.back().type != ContextType::Array) {
+      error_ = true;
+      return;
+    }
+    buffer_.push_back(']');
+    stack_.pop_back();
+  }
+
+  void Key(const std::string &key) {
+    if (stack_.empty() || stack_.back().type != ContextType::Object ||
+        stack_.back().expect_value) {
+      error_ = true;
+      return;
+    }
+    ContextInfo &ctx = stack_.back();
+    if (!ctx.first) {
+      buffer_.push_back(',');
+    }
+    ctx.first = false;
+    WriteEscapedString(key);
+    buffer_.push_back(':');
+    ctx.expect_value = true;
+  }
+
+  void String(const std::string &value) {
+    WriteValuePrefix();
+    WriteEscapedString(value);
+  }
+
+  void Number(int64_t value) {
+    WriteValuePrefix();
+    buffer_ += std::to_string(value);
+  }
+
+  void Null() {
+    WriteValuePrefix();
+    buffer_ += "null";
+  }
+
+  bool IsOk() const { return !error_ && stack_.empty(); }
+
+  const std::string &Get() const { return buffer_; }
+
+ private:
+  enum class ContextType { Object, Array };
+
+  struct ContextInfo {
+    ContextType type;
+    bool first;
+    bool expect_value;
+  };
+
+  void WriteValuePrefix() {
+    if (stack_.empty()) {
+      return;
+    }
+    ContextInfo &ctx = stack_.back();
+    if (ctx.type == ContextType::Array) {
+      if (!ctx.first) {
+        buffer_.push_back(',');
+      }
+      ctx.first = false;
+    } else {
+      if (!ctx.expect_value) {
+        error_ = true;
+        return;
+      }
+      ctx.expect_value = false;
+    }
+  }
+
+  void WriteEscapedString(const std::string &value) {
+    buffer_.push_back('"');
+    for (const unsigned char ch : value) {
+      switch (ch) {
+        case '\\':
+          buffer_ += "\\\\";
+          break;
+        case '"':
+          buffer_ += "\\\"";
+          break;
+        case '\b':
+          buffer_ += "\\b";
+          break;
+        case '\f':
+          buffer_ += "\\f";
+          break;
+        case '\n':
+          buffer_ += "\\n";
+          break;
+        case '\r':
+          buffer_ += "\\r";
+          break;
+        case '\t':
+          buffer_ += "\\t";
+          break;
+        default:
+          if (ch < 0x20) {
+            char buffer[7];
+            std::snprintf(buffer, sizeof(buffer), "\\u%04x", ch);
+            buffer_ += buffer;
+          } else {
+            buffer_.push_back(static_cast<char>(ch));
+          }
+          break;
+      }
+    }
+    buffer_.push_back('"');
+  }
+
+  std::string buffer_;
+  std::vector<ContextInfo> stack_;
+  bool error_ = false;
+};
+
+bool WriteAllBytes(HANDLE handle, const std::string &data) {
+  if (handle == nullptr || handle == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+  if (data.empty()) {
+    return true;
+  }
+  const char *ptr = data.data();
+  size_t remaining = data.size();
+  while (remaining > 0) {
+    const DWORD chunk = static_cast<DWORD>(
+        std::min<size_t>(remaining, std::numeric_limits<DWORD>::max()));
+    DWORD written = 0;
+    if (!WriteFile(handle, ptr, chunk, &written, nullptr)) {
+      return false;
+    }
+    if (written == 0) {
+      return false;
+    }
+    ptr += written;
+    remaining -= written;
+  }
+  return true;
+}
+
+}  // namespace
+
+bool WriteManifest(const ManifestInfo &info) {
+  if (info.out_dir.empty()) {
+    std::wcerr << L"ERROR: Manifest output directory is empty.\n";
+    return false;
+  }
+
+  JsonWriter writer;
+  writer.BeginObject();
+  writer.Key("tool_version");
+  writer.String("visdriver+verify/0.1");
+
+  writer.Key("inputs");
+  writer.BeginObject();
+  writer.Key("vis_dll");
+  writer.String(PathToUtf8(info.vis_dll_path));
+  writer.Key("runtime_dir");
+  writer.String(PathToUtf8(info.runtime_dir));
+  writer.Key("vis_avs_dat");
+  if (info.has_vis_avs_dat) {
+    writer.String(PathToUtf8(info.vis_avs_dat_path));
+  } else {
+    writer.Null();
+  }
+  writer.Key("preset");
+  if (info.has_preset) {
+    writer.String(PathToUtf8(info.preset_path));
+  } else {
+    writer.Null();
+  }
+  writer.Key("wav");
+  writer.BeginObject();
+  writer.Key("path");
+  writer.String(PathToUtf8(info.wav_path));
+  writer.Key("sample_rate");
+  writer.Number(info.wav_sample_rate);
+  writer.Key("channels");
+  writer.Number(info.wav_channels);
+  writer.Key("sample_count");
+  writer.Number(info.wav_sample_count);
+  writer.EndObject();
+  writer.EndObject();
+
+  writer.Key("render");
+  writer.BeginObject();
+  writer.Key("width");
+  writer.Number(info.width);
+  writer.Key("height");
+  writer.Number(info.height);
+  writer.Key("fps");
+  writer.Number(info.fps);
+  writer.Key("frames");
+  writer.Number(info.frames);
+  writer.EndObject();
+
+  writer.Key("outputs");
+  writer.BeginObject();
+  writer.Key("png_frames");
+  writer.BeginArray();
+  for (const auto &png_path : info.png_paths) {
+    const std::filesystem::path relative =
+        MakeRelativeIfPossible(png_path, info.out_dir);
+    writer.String(PathToUtf8(relative));
+  }
+  writer.EndArray();
+  writer.Key("per_frame_hashes");
+  writer.String(PathToUtf8(
+      MakeRelativeIfPossible(info.per_frame_hash_path, info.out_dir)));
+  writer.Key("rolling_hash");
+  writer.String(PathToUtf8(
+      MakeRelativeIfPossible(info.rolling_hash_path, info.out_dir)));
+  writer.Key("avi");
+  if (info.has_avi_output) {
+    writer.String(PathToUtf8(
+        MakeRelativeIfPossible(info.avi_output_path, info.out_dir)));
+  } else {
+    writer.Null();
+  }
+  writer.EndObject();
+
+  writer.EndObject();
+
+  if (!writer.IsOk()) {
+    std::wcerr << L"ERROR: Failed to encode manifest JSON.\n";
+    return false;
+  }
+
+  const std::string json = writer.Get();
+  const std::filesystem::path manifest_path = info.out_dir / L"manifest.json";
+  HANDLE handle = CreateFileW(manifest_path.c_str(), GENERIC_WRITE,
+                              FILE_SHARE_READ, nullptr, CREATE_ALWAYS,
+                              FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (handle == nullptr || handle == INVALID_HANDLE_VALUE) {
+    const DWORD error = GetLastError();
+    std::wcerr << L"ERROR: Failed to create manifest '"
+               << manifest_path.wstring() << L"' (error " << error << L").\n";
+    return false;
+  }
+
+  bool ok = WriteAllBytes(handle, json);
+  if (ok) {
+    if (!FlushFileBuffers(handle)) {
+      ok = false;
+    }
+  }
+
+  CloseHandle(handle);
+
+  if (!ok) {
+    std::wcerr << L"ERROR: Failed to write manifest file.\n";
+  }
+
+  return ok;
+}

--- a/tools/manifest.hpp
+++ b/tools/manifest.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+struct ManifestInfo {
+  std::filesystem::path out_dir;
+  std::filesystem::path vis_dll_path;
+  std::filesystem::path runtime_dir;
+  std::filesystem::path vis_avs_dat_path;
+  std::filesystem::path preset_path;
+  std::filesystem::path wav_path;
+  int wav_sample_rate = 0;
+  int wav_channels = 0;
+  int64_t wav_sample_count = 0;
+  int width = 0;
+  int height = 0;
+  int fps = 0;
+  int frames = 0;
+  std::vector<std::filesystem::path> png_paths;
+  std::filesystem::path per_frame_hash_path;
+  std::filesystem::path rolling_hash_path;
+  std::filesystem::path avi_output_path;
+  bool has_vis_avs_dat = false;
+  bool has_preset = false;
+  bool has_avi_output = false;
+};
+
+bool WriteManifest(const ManifestInfo &info);


### PR DESCRIPTION
## Summary
- add a minimal AVI writer based on the VFW API and hook it into generate-verification-data
- emit a machine-readable manifest.json with inputs, render settings, and output metadata
- update the build to compile the new helpers and link against Vfw32/vfw32

## Testing
- cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake *(fails: i686-w64-mingw32-gcc not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b05de30c832c9156d05d2e00e188