### PR TITLE
Fix MinGW compilation incompatibilities

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -77,8 +77,7 @@ static void require_argument_that_is_wired_to(const char *const *target,
   exit(1);
 }
 
-void parse_command_line(visdriver_config_t *config, int argc,
-                        const char **argv) {
+void parse_command_line(visdriver_config_t *config, int argc, char **argv) {
   static const char *const usages[] = {
       "visdriver [OPTIONS] --in PATH/IN.dll --out PATH/OUT.dll --vis "
       "PATH/VIS.dll [--] [AUDIO_FILE ..]",
@@ -118,7 +117,9 @@ void parse_command_line(visdriver_config_t *config, int argc,
   argparse_init(&argparse, options, usages, 0);
   argparse_describe(&argparse, description, epilog);
 
-  argc = argparse_parse(&argparse, argc, argv);
+  // `argv` values originate from the C runtime and remain immutable here.
+  const char *const *const argv_ro = (const char *const *)argv;
+  argc = argparse_parse(&argparse, argc, argv_ro);
 
   // Check for required arguments
   require_argument_that_is_wired_to(&config->input_plugin_filename, &argparse,
@@ -133,6 +134,6 @@ void parse_command_line(visdriver_config_t *config, int argc,
       "line://"; // for in_line.dll or in_linein.dll
   const char *const *const default_tracks = &default_track;
 
-  config->tracks = (argc >= 1) ? (const char *const *)argv : default_tracks;
+  config->tracks = (argc >= 1) ? argv_ro : default_tracks;
   config->track_count = (argc >= 1) ? argc : 1;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -26,7 +26,6 @@ typedef struct _visdriver_config_t {
   int track_count;
 } visdriver_config_t;
 
-void parse_command_line(visdriver_config_t *config, int argc,
-                        const char **argv);
+void parse_command_line(visdriver_config_t *config, int argc, char **argv);
 
 #endif // ifndef CONFIG_H

--- a/tools/avi_writer.cpp
+++ b/tools/avi_writer.cpp
@@ -38,7 +38,7 @@ bool AviWriter::Open(const std::wstring &path, int width, int height, int fps) {
     return false;
   }
 
-  AVISTREAMINFO info;
+  AVISTREAMINFOW info;
   std::memset(&info, 0, sizeof(info));
   info.fccType = streamtypeVIDEO;
   info.dwScale = 1;


### PR DESCRIPTION
## Summary
- align the `parse_command_line` signature with `main` so MinGW no longer warns about passing `argv`
- ensure the AVI writer uses the wide-character stream info structure with `AVIFileCreateStreamW`

## Testing
- `cmake -S . -B build` *(fails: project requires specifying a MinGW toolchain file in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c39bfc10832c90a4d8d8380730ab