### PR TITLE
Fix WM_WA_IPC handling for embedded child window

### DIFF
--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -233,7 +233,14 @@ LRESULT CALLBACK AvsWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
       ResizeEmbeddedWindow(hwnd);
       break;
 
-    case WM_WA_IPC:
+    case WM_WA_IPC: {
+      const bool from_parent = (hwnd == g_parent_window);
+      const bool from_child = (hwnd == g_child_container_window);
+      const bool from_embedded = (hwnd == g_embedded_vis_window);
+      if (!from_parent && !from_child && !from_embedded) {
+        break;
+      }
+
       switch (lParam) {
         case IPC_GETVERSION:
           return 0x2900;
@@ -277,6 +284,7 @@ LRESULT CALLBACK AvsWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
           return 0;
       }
       break;
+    }
   }
 
   return DefWindowProcW(hwnd, msg, wParam, lParam);

--- a/tools/vis_host.cpp
+++ b/tools/vis_host.cpp
@@ -108,8 +108,9 @@ bool begin_vis(VisHost &host, int width, int height) {
     return false;
   }
 
-  HWND const target_window = (host.child != nullptr) ? host.child : host.parent;
-  host.mod->hwndParent = target_window;
+  HWND const module_parent =
+      (host.parent != nullptr) ? host.parent : host.child;
+  host.mod->hwndParent = module_parent;
   host.mod->hDllInstance = host.dll;
   host.mod->sRate = 44100;
   host.mod->nCh = 2;
@@ -117,6 +118,8 @@ bool begin_vis(VisHost &host, int width, int height) {
   host.mod->spectrumNch = 2;
   host.mod->waveformNch = 2;
 
+  HWND const target_window =
+      (host.child != nullptr) ? host.child : module_parent;
   if (target_window != nullptr) {
     SetWindowPos(target_window, nullptr, 0, 0, width, height,
                  SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOMOVE);


### PR DESCRIPTION
## Summary
- ensure visualization modules receive the Winamp parent window handle
- allow the WM_WA_IPC handler to respond to messages sent via the child container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0779477bc832c9cb1bd3770a73fd9