### PR TITLE
Handle WM_WA_IPC messages from the visualization host

### DIFF
--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -46,6 +46,13 @@ HWND g_parent_window = nullptr;
 HWND g_child_container_window = nullptr;
 HWND g_embedded_vis_window = nullptr;
 
+HWND GetContainerWindow() {
+  if (g_child_container_window != nullptr) {
+    return g_child_container_window;
+  }
+  return g_parent_window;
+}
+
 struct HandleCloser {
   void operator()(HANDLE handle) const {
     if (handle != nullptr && handle != INVALID_HANDLE_VALUE) {
@@ -193,11 +200,11 @@ std::wstring FormatFrameFilename(int frame_index) {
 }
 
 static HWND embed_window(embedWindowState *state) {
-  (void)state;
-  if (g_child_container_window != nullptr) {
-    return g_child_container_window;
+  HWND const container = GetContainerWindow();
+  if (state != nullptr) {
+    state->me = container;
   }
-  return g_parent_window;
+  return container;
 }
 
 void ResizeEmbeddedWindow(HWND container) {
@@ -230,7 +237,7 @@ LRESULT CALLBACK AvsWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
 
     case WM_SIZE:
     case WM_SIZING:
-      ResizeEmbeddedWindow(hwnd);
+      ResizeEmbeddedWindow(GetContainerWindow());
       break;
 
     case WM_WA_IPC:
@@ -258,23 +265,22 @@ LRESULT CALLBACK AvsWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
           }
           return reinterpret_cast<LRESULT>(ini_path);
         }
-        case IPC_GET_EMBEDIF:
-          if (g_parent_window != nullptr) {
-            ShowWindow(g_parent_window, SW_SHOW);
+        case IPC_GET_EMBEDIF: {
+          HWND const container = GetContainerWindow();
+          if (container != nullptr) {
+            ShowWindow(container, SW_SHOW);
           }
           if (wParam == 0) {
             return reinterpret_cast<LRESULT>(embed_window);
           }
           return reinterpret_cast<LRESULT>(
               embed_window(reinterpret_cast<embedWindowState *>(wParam)));
-        case IPC_SETVISWND:
+        }
+        case IPC_SETVISWND: {
           g_embedded_vis_window = reinterpret_cast<HWND>(wParam);
-          if (g_child_container_window != nullptr) {
-            ResizeEmbeddedWindow(g_child_container_window);
-          } else if (g_parent_window != nullptr) {
-            ResizeEmbeddedWindow(g_parent_window);
-          }
+          ResizeEmbeddedWindow(GetContainerWindow());
           return 0;
+        }
       }
       break;
   }

--- a/tools/vis_host.cpp
+++ b/tools/vis_host.cpp
@@ -108,8 +108,12 @@ bool begin_vis(VisHost &host, int width, int height) {
     return false;
   }
 
-  HWND const target_window = (host.child != nullptr) ? host.child : host.parent;
-  host.mod->hwndParent = target_window;
+  HWND const ipc_target_window =
+      (host.parent != nullptr) ? host.parent : host.child;
+  HWND const container_window =
+      (host.child != nullptr) ? host.child : host.parent;
+
+  host.mod->hwndParent = ipc_target_window;
   host.mod->hDllInstance = host.dll;
   host.mod->sRate = 44100;
   host.mod->nCh = 2;
@@ -117,8 +121,8 @@ bool begin_vis(VisHost &host, int width, int height) {
   host.mod->spectrumNch = 2;
   host.mod->waveformNch = 2;
 
-  if (target_window != nullptr) {
-    SetWindowPos(target_window, nullptr, 0, 0, width, height,
+  if (container_window != nullptr) {
+    SetWindowPos(container_window, nullptr, 0, 0, width, height,
                  SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOMOVE);
   }
 


### PR DESCRIPTION
## Summary
- return the child container handle from IPC_GET_EMBEDIF and resize the vis window from whichever container is active
- update the WM_WA_IPC handler to show and resize using the tracked container window
- pass the parent window handle to the visualization module so WM_WA_IPC is delivered to the expected window proc

## Testing
- not run (cross-compilation toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0779477bc832c9cb1bd3770a73fd9