### PR TITLE
Handle WM_WA_IPC from child container

### DIFF
--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -234,6 +234,9 @@ LRESULT CALLBACK AvsWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
       break;
 
     case WM_WA_IPC:
+      if (hwnd != g_parent_window && hwnd != g_child_container_window) {
+        break;
+      }
       switch (lParam) {
         case IPC_GETVERSION:
           return 0x2900;
@@ -269,11 +272,15 @@ LRESULT CALLBACK AvsWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
               embed_window(reinterpret_cast<embedWindowState *>(wParam)));
         case IPC_SETVISWND:
           g_embedded_vis_window = reinterpret_cast<HWND>(wParam);
-          if (g_child_container_window != nullptr) {
-            ResizeEmbeddedWindow(g_child_container_window);
-          } else if (g_parent_window != nullptr) {
-            ResizeEmbeddedWindow(g_parent_window);
+          HWND container = nullptr;
+          if (hwnd == g_child_container_window) {
+            container = g_child_container_window;
+          } else if (g_child_container_window != nullptr) {
+            container = g_child_container_window;
+          } else {
+            container = g_parent_window;
           }
+          ResizeEmbeddedWindow(container);
           return 0;
       }
       break;


### PR DESCRIPTION
## Summary
- allow the WM_WA_IPC handler to service messages sent to either the hidden parent window or the child container
- ensure IPC_SETVISWND triggers a resize of the embedded visualization window regardless of which host window received the message

## Testing
- not run (Win32-only runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e0779477bc832c9cb1bd3770a73fd9