### PR TITLE
Fix DROPFILES usage and stabilize audio DSP call convention

### DIFF
--- a/src/audio_dsp.c
+++ b/src/audio_dsp.c
@@ -15,13 +15,14 @@
 // You should have received a copy of the GNU General Public License along
 // with visdriver. If not, see <https://www.gnu.org/licenses/>.
 
+#include "audio_dsp.h"
 #include "log.h"
 
-int __cdecl dsp_isactive() {
+int AUDIO_DSP_CALLCONV dsp_isactive(void) {
   return 1; // i.e. active
 }
 
-int __cdecl dsp_dosamples(short int *samples, int numsamples, int bps, int nch,
-                          int srate) {
+int AUDIO_DSP_CALLCONV dsp_dosamples(short int *samples, int numsamples,
+                                     int bps, int nch, int srate) {
   return numsamples; // i.e. unchanged number of samples
 }

--- a/src/audio_dsp.h
+++ b/src/audio_dsp.h
@@ -18,9 +18,19 @@
 #ifndef AUDIO_DSP_H
 #define AUDIO_DSP_H
 
-int __cdecl dsp_isactive();
+#if !defined(AUDIO_DSP_CALLCONV)
+#if defined(_MSC_VER)
+#define AUDIO_DSP_CALLCONV __cdecl
+#elif defined(__MINGW32__) || defined(__MINGW64__) || defined(__GNUC__)
+#define AUDIO_DSP_CALLCONV __attribute__((__cdecl__))
+#else
+#define AUDIO_DSP_CALLCONV
+#endif
+#endif
 
-int __cdecl dsp_dosamples(short int *samples, int numsamples, int bps, int nch,
-                          int srate);
+int AUDIO_DSP_CALLCONV dsp_isactive(void);
+
+int AUDIO_DSP_CALLCONV dsp_dosamples(short int *samples, int numsamples,
+                                     int bps, int nch, int srate);
 
 #endif // ifndef AUDIO_DSP_H

--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -23,6 +23,16 @@
 #include <windows.h>
 #include <shellapi.h>
 
+#ifndef __DROPFILES_DEFINED
+typedef struct _DROPFILES {
+  DWORD pFiles;
+  POINT pt;
+  BOOL fNC;
+  BOOL fWide;
+} DROPFILES, *LPDROPFILES;
+#define __DROPFILES_DEFINED
+#endif
+
 #include <winamp/out.h>
 #include <winamp/wa_ipc.h>
 


### PR DESCRIPTION
## Summary
- provide a fallback definition for DROPFILES when shellapi.h does not expose it
- unblock the preset drag-and-drop code path from build failures on some MinGW environments
- add an AUDIO_DSP_CALLCONV fallback so the audio DSP stub compiles even when __cdecl is undefined

## Testing
- cmake -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake -S . -B build *(fails: MinGW cross-compilers are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e088c9de00832cb742cfbea9f4b857