### PR TITLE
Handle MsgWaitForMultipleObjects failures when waiting for AVS window

### DIFF
--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -136,9 +136,19 @@ bool WaitForEmbeddedVisWindow(const VisHost &host, DWORD timeout_ms) {
     const ULONGLONG remaining = timeout - elapsed;
     const DWORD wait_duration =
         static_cast<DWORD>(std::min<ULONGLONG>(remaining, 50));
-    const DWORD wait_result = MsgWaitForMultipleObjects(
-        0, nullptr, FALSE, wait_duration, QS_ALLINPUT);
+    const DWORD wait_result = MsgWaitForMultipleObjectsEx(
+        0, nullptr, wait_duration, QS_ALLINPUT, MWMO_INPUTAVAILABLE);
     if (wait_result == WAIT_FAILED) {
+      const DWORD wait_error = GetLastError();
+      if (wait_error == ERROR_INVALID_PARAMETER) {
+        if (wait_duration > 0) {
+          Sleep(wait_duration);
+        } else {
+          Sleep(1);
+        }
+        RequestEmbeddedVisWindow(host);
+        continue;
+      }
       break;
     }
 


### PR DESCRIPTION
## Summary
- guard the wait loop used to locate the embedded AVS window against MsgWaitForMultipleObjects failures
- fall back to a timed sleep when Wine reports ERROR_INVALID_PARAMETER so preset loads can continue

## Testing
- cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake
- cmake --build build *(fails: missing Windows headers in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0974d9c5c832cb1b7a6c1aa9c540d