### PR TITLE
Keep AVS frame loop responsive

### DIFF
--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -1199,6 +1199,20 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
   Sha256 rolling_hash;
 
   for (int frame = 0; frame < options.frames; ++frame) {
+    if (!PumpPendingWindowMessages()) {
+      break;
+    }
+
+    const DWORD pump_delay =
+        (host.mod != nullptr && host.mod->delayMs > 0)
+            ? static_cast<DWORD>(host.mod->delayMs)
+            : 0;
+    if (pump_delay > 0) {
+      Sleep(pump_delay);
+    } else {
+      Sleep(0);
+    }
+
     const int samples_per_frame =
         static_cast<int>(std::lround(44100.0 / effective_fps));
     const int hop = std::max(1, samples_per_frame / kWaveformSamples);
@@ -1232,6 +1246,10 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
 
     const int render_result = host.mod->Render(host.mod);
     if (render_result != 0) {
+      break;
+    }
+
+    if (!PumpPendingWindowMessages()) {
       break;
     }
 


### PR DESCRIPTION
## Summary
- pump the Windows message queue during frame generation and abort on WM_QUIT
- yield briefly between frames using the module-provided delay to avoid pegging the CPU
- re-pump after rendering so the embedded window hierarchy stays responsive

## Testing
- not run (hosted Linux container without AVS)


------
https://chatgpt.com/codex/tasks/task_e_68e0a045cddc832cb7ac0758f2b228ed