### PR TITLE
Add Windows diagnostics instrumentation for AVS capture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(visdriver
         tools/spectrum.cpp
         tools/wav_reader.cpp
         tools/vis_host.cpp
+        tools/windows_diagnostics.cpp
         src/thirdparty/argparse/argparse.c
         third_party/kissfft/kiss_fft.c
         third_party/kissfft/kiss_fftr.c

--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -43,6 +43,7 @@ typedef struct _DROPFILES {
 #include "sha256.hpp"
 #include "vis_host.hpp"
 #include "wav_reader.hpp"
+#include "windows_diagnostics.hpp"
 
 namespace {
 
@@ -985,6 +986,19 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     return 1;
   }
 
+  const std::filesystem::path diagnostics_log_path =
+      out_dir_path / L"diagnostics.log";
+  diagnostics::Initialize(diagnostics_log_path.wstring());
+  diagnostics::InstallForCurrentProcess();
+  struct DiagnosticsShutdownGuard {
+    ~DiagnosticsShutdownGuard() { diagnostics::Shutdown(); }
+  } diagnostics_shutdown_guard;
+  diagnostics::Logf(
+      L"Diagnostics initialized (vis='%ls', wav='%ls', size=%dx%d, fps=%d, "
+      L"frames=%d)",
+      options.vis_dll.c_str(), options.wav.c_str(), options.width,
+      options.height, options.fps, options.frames);
+
   const std::filesystem::path per_frame_csv_path =
       hashes_dir_path / L"per_frame.csv";
   const std::filesystem::path rolling_hash_path =
@@ -1000,6 +1014,8 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
                << FormatWindowsErrorMessage(error) << L"\n";
     return 1;
   }
+  diagnostics::Logf(L"Per-frame hash output: %ls",
+                    per_frame_csv_path.c_str());
 
   std::vector<int16_t> audio_pcm;
   int wav_sample_rate = 0;
@@ -1023,9 +1039,14 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     wav_sample_rate = 44100;
     wav_channels = 2;
     wav_sample_count = static_cast<int64_t>(total_samples);
+    diagnostics::Logf(L"WAV loaded: rate=%d channels=%d samples=%lld",
+                      wav_sample_rate, wav_channels,
+                      static_cast<long long>(wav_sample_count));
   } catch (const std::exception &ex) {
-    std::wcerr << L"ERROR: Failed to load WAV: "
-               << ConvertToWide(std::string(ex.what())) << L"\n";
+    const std::wstring error_message =
+        ConvertToWide(std::string(ex.what()));
+    std::wcerr << L"ERROR: Failed to load WAV: " << error_message << L"\n";
+    diagnostics::Logf(L"Failed to load WAV: %ls", error_message.c_str());
     return 1;
   }
 
@@ -1038,17 +1059,25 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
   }
   std::wcout << L"Switched to runtime directory: " << options.runtime_dir
              << L"\n";
+  diagnostics::Logf(L"SetCurrentDirectory -> %ls", options.runtime_dir.c_str());
 
+  diagnostics::Logf(L"Creating hidden parent window (%dx%d)", options.width,
+                    options.height);
   HWND parent_window = CreateHiddenParentWindow(options.width, options.height);
   if (parent_window == nullptr) {
     return 1;
   }
+  diagnostics::RegisterWindowTag(parent_window, L"visdriver.parent");
+  diagnostics::Logf(L"Parent window handle: %p", parent_window);
 
+  diagnostics::Logf(L"Loading vis module from %ls", options.vis_dll.c_str());
   VisHost host = load_vis(options.vis_dll, parent_window);
   if (host.dll == nullptr || host.hdr == nullptr || host.mod == nullptr) {
     unload_vis(host);
     return 1;
   }
+  diagnostics::InstallForModule(host.dll);
+  diagnostics::Logf(L"vis module handle=%p", host.dll);
 
   std::wstring header_description = ConvertAnsiToWide(host.hdr->description);
   if (header_description.empty()) {
@@ -1061,28 +1090,40 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
   std::wcout << L"Loaded vis module: " << header_description << L"\n";
   std::wcout << L"  module description: " << module_description << L"\n";
 
+  diagnostics::Logf(L"Creating child container (%dx%d)", options.width,
+                    options.height);
   host.child = CreateChildWindow(parent_window, options.width, options.height);
   if (host.child == nullptr) {
     unload_vis(host);
     return 1;
   }
+  diagnostics::RegisterWindowTag(host.child, L"visdriver.child");
+  diagnostics::Logf(L"Child window handle: %p", host.child);
+
+  diagnostics::SetCaptureBounds(options.width, options.height);
 
   host.mod->delayMs = (options.fps > 0) ? (1000 / options.fps) : 0;
+  diagnostics::Logf(L"Calling Init() on vis module");
   if (!begin_vis(host, options.width, options.height)) {
+    diagnostics::Logf(L"begin_vis failed");
     unload_vis(host);
     return 1;
   }
+  diagnostics::Logf(L"Vis module initialized successfully");
 
   if (!options.preset.empty()) {
     if (!std::filesystem::exists(options.preset)) {
       std::wcerr << L"ERROR: Preset file not found: " << options.preset << L"\n";
+      diagnostics::Logf(L"Preset file missing: %ls", options.preset.c_str());
       end_vis(host);
       unload_vis(host);
       return 1;
     }
 
+    diagnostics::Logf(L"Waiting for embedded vis window (5000 ms)");
     if (!WaitForEmbeddedVisWindow(host, 5000)) {
       std::wcerr << L"ERROR: Failed to locate AVS window for preset load (timeout).\n";
+      diagnostics::Logf(L"Embedded vis window not found before timeout.");
       end_vis(host);
       unload_vis(host);
       return 1;
@@ -1091,10 +1132,13 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     HWND preset_window = g_embedded_vis_window;
     if (preset_window == nullptr || !IsWindow(preset_window)) {
       std::wcerr << L"ERROR: Failed to locate AVS window for preset load.\n";
+      diagnostics::Logf(L"Embedded vis window handle invalid.");
       end_vis(host);
       unload_vis(host);
       return 1;
     }
+    diagnostics::RegisterWindowTag(preset_window, L"avs.embedded");
+    diagnostics::Logf(L"Embedded vis window handle=%p", preset_window);
 
     const size_t preset_length = options.preset.size();
     const size_t buffer_size =
@@ -1157,6 +1201,7 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     }
 
     std::wcout << L"Loaded preset: " << options.preset << L"\n";
+    diagnostics::Logf(L"Preset delivered to AVS: %ls", options.preset.c_str());
   }
 
   if (host.mod->Render == nullptr) {
@@ -1198,6 +1243,7 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
   }
   Sha256 rolling_hash;
 
+  int frames_rendered = 0;
   for (int frame = 0; frame < options.frames; ++frame) {
     const int samples_per_frame =
         static_cast<int>(std::lround(44100.0 / effective_fps));
@@ -1230,17 +1276,43 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     std::wcout << L"Frame " << (frame + 1) << L"/" << options.frames
                << L": start=" << start_sample << L", hop=" << hop << L"\n";
 
+    diagnostics::Logf(L"Frame %d: invoking Render (start=%d hop=%d)", frame,
+                      start_sample, hop);
     const int render_result = host.mod->Render(host.mod);
+    diagnostics::Logf(L"Frame %d: Render returned %d", frame, render_result);
     if (render_result != 0) {
       break;
     }
 
-    if (!capture_child_to_rgba(host.child, options.width, options.height,
-                               frame_rgba)) {
+    bool frame_captured =
+        capture_child_to_rgba(host.child, options.width, options.height,
+                              frame_rgba);
+    if (!frame_captured) {
+      diagnostics::Logf(
+          L"Frame %d: window capture failed (hwnd=%p), attempting fallback",
+          frame, host.child);
+      std::vector<uint8_t> fallback_rgba;
+      uint64_t capture_generation = 0;
+      if (diagnostics::FetchLastFrame(fallback_rgba, capture_generation)) {
+        diagnostics::Logf(L"Frame %d: using diagnostics capture #%llu", frame,
+                          static_cast<unsigned long long>(capture_generation));
+        frame_rgba = std::move(fallback_rgba);
+        frame_captured = true;
+      } else {
+        diagnostics::Logf(L"Frame %d: no diagnostics capture available", frame);
+      }
+    } else {
+      diagnostics::Logf(L"Frame %d: captured via window", frame);
+    }
+
+    if (!frame_captured) {
       std::wcerr << L"ERROR: Failed to capture frame " << frame << L".\n";
       capture_failed = true;
       break;
     }
+    frames_rendered = frame + 1;
+    diagnostics::Logf(L"Frame %d: capture complete (%zu bytes)", frame,
+                      frame_rgba.size());
 
     if (avi_enabled && !avi_failed) {
       if (!avi_opened) {
@@ -1276,6 +1348,8 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
         capture_failed = true;
         break;
       }
+      diagnostics::Logf(L"Frame %d: wrote PNG %ls", frame,
+                        png_path.wstring().c_str());
       png_outputs.push_back(png_path);
       std::wcout << L"Wrote " << png_path << L"\n";
     }
@@ -1284,6 +1358,11 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
   if (avi_writer.IsOpen()) {
     avi_writer.Close();
   }
+
+  diagnostics::Logf(
+      L"Render loop finished: frames_rendered=%d capture_failed=%d hash_failed=%d avi_failed=%d",
+      frames_rendered, capture_failed ? 1 : 0, hash_failed ? 1 : 0,
+      avi_failed ? 1 : 0);
 
   if (!capture_failed && !hash_failed && !avi_failed) {
     if (!FlushFileBuffers(per_frame_file.get())) {
@@ -1294,9 +1373,13 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     }
   }
 
+  diagnostics::Logf(L"Stopping visualization module");
   end_vis(host);
+  diagnostics::Logf(L"Visualization module stopped");
 
+  diagnostics::Logf(L"Unloading vis module");
   unload_vis(host);
+  diagnostics::Logf(L"vis module unloaded");
 
   if (!capture_failed && !hash_failed && !avi_failed) {
     const std::array<uint8_t, 32> rolling_digest = rolling_hash.Final();

--- a/tools/vis_host.cpp
+++ b/tools/vis_host.cpp
@@ -2,6 +2,8 @@
 
 #include <iostream>
 
+#include "windows_diagnostics.hpp"
+
 namespace {
 
 std::wstring FormatWindowsErrorMessage(DWORD error_code) {
@@ -35,11 +37,14 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   VisHost host;
   host.parent = parent;
 
+  diagnostics::Logf(L"load_vis: loading %ls", dll_path.c_str());
   host.dll = LoadLibraryW(dll_path.c_str());
   if (host.dll == nullptr) {
     const DWORD error = GetLastError();
     std::wcerr << L"ERROR: Failed to load vis DLL '" << dll_path
                << L"': " << FormatWindowsErrorMessage(error) << L"\n";
+    diagnostics::Logf(L"load_vis: LoadLibraryW failed (%ls)",
+                      FormatWindowsErrorMessage(error).c_str());
     return host;
   }
 
@@ -47,6 +52,7 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   if (proc == nullptr) {
     std::wcerr << L"ERROR: Symbol 'winampVisGetHeader' not found in '" << dll_path
                << L"'.\n";
+    diagnostics::Logf(L"load_vis: winampVisGetHeader missing");
     FreeLibrary(host.dll);
     host.dll = nullptr;
     return host;
@@ -57,6 +63,7 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   if (header == nullptr) {
     std::wcerr << L"ERROR: winampVisGetHeader returned null for '" << dll_path
                << L"'.\n";
+    diagnostics::Logf(L"load_vis: header null");
     FreeLibrary(host.dll);
     host.dll = nullptr;
     return host;
@@ -65,6 +72,7 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   if (header->getModule == nullptr) {
     std::wcerr << L"ERROR: winampVisHeader::getModule is null in '" << dll_path
                << L"'.\n";
+    diagnostics::Logf(L"load_vis: getModule null");
     FreeLibrary(host.dll);
     host.dll = nullptr;
     return host;
@@ -74,6 +82,7 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   if (module == nullptr) {
     std::wcerr << L"ERROR: Failed to fetch first vis module from '" << dll_path
                << L"'.\n";
+    diagnostics::Logf(L"load_vis: getModule(0) returned null");
     FreeLibrary(host.dll);
     host.dll = nullptr;
     return host;
@@ -81,30 +90,37 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
 
   host.hdr = header;
   host.mod = module;
+  diagnostics::Logf(L"load_vis: success module=%p", host.mod);
 
   return host;
 }
 
 void unload_vis(VisHost &host) {
+  diagnostics::Logf(L"unload_vis: begin");
   if (host.child != nullptr) {
+    diagnostics::Logf(L"unload_vis: destroying child %p", host.child);
     DestroyWindow(host.child);
     host.child = nullptr;
   }
   if (host.parent != nullptr) {
+    diagnostics::Logf(L"unload_vis: destroying parent %p", host.parent);
     DestroyWindow(host.parent);
     host.parent = nullptr;
   }
   host.hdr = nullptr;
   host.mod = nullptr;
   if (host.dll != nullptr) {
+    diagnostics::Logf(L"unload_vis: freeing dll %p", host.dll);
     FreeLibrary(host.dll);
     host.dll = nullptr;
   }
+  diagnostics::Logf(L"unload_vis: done");
 }
 
 bool begin_vis(VisHost &host, int width, int height) {
   if (host.mod == nullptr) {
     std::wcerr << L"ERROR: Visualization module handle is null.\n";
+    diagnostics::Logf(L"begin_vis: module null");
     return false;
   }
 
@@ -124,26 +140,35 @@ bool begin_vis(VisHost &host, int width, int height) {
 
   if (host.mod->Init == nullptr) {
     std::wcerr << L"ERROR: Visualization module is missing Init().\n";
+    diagnostics::Logf(L"begin_vis: Init missing");
     return false;
   }
 
+  diagnostics::Logf(L"begin_vis: calling Init (target=%p)", target_window);
   const int init_result = host.mod->Init(host.mod);
   if (init_result != 0) {
     std::wcerr << L"ERROR: Visualization module Init() returned "
                << init_result << L".\n";
+    diagnostics::Logf(L"begin_vis: Init returned %d", init_result);
     return false;
   }
+
+  diagnostics::Logf(L"begin_vis: Init succeeded");
 
   return true;
 }
 
 void end_vis(VisHost &host) {
+  diagnostics::Logf(L"end_vis: begin");
   if (host.mod != nullptr && host.mod->Quit != nullptr) {
     host.mod->Quit(host.mod);
+    diagnostics::Logf(L"end_vis: Quit called");
   }
 
   if (host.child != nullptr) {
+    diagnostics::Logf(L"end_vis: destroying child %p", host.child);
     DestroyWindow(host.child);
     host.child = nullptr;
   }
+  diagnostics::Logf(L"end_vis: done");
 }

--- a/tools/windows_diagnostics.cpp
+++ b/tools/windows_diagnostics.cpp
@@ -1,0 +1,804 @@
+#include "windows_diagnostics.hpp"
+
+#if defined(_WIN32)
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cwchar>
+#include <cstring>
+#include <string.h>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <winternl.h>
+
+namespace diagnostics {
+namespace {
+
+struct Logger {
+  std::mutex mutex;
+  FILE *file = nullptr;
+  bool initialized = false;
+};
+
+Logger g_logger;
+
+struct WindowInfo {
+  std::wstring class_name;
+  std::wstring title;
+  DWORD style = 0;
+  DWORD ex_style = 0;
+  HWND parent = nullptr;
+  std::wstring tag;
+};
+
+struct DcInfo {
+  HWND owner = nullptr;
+  bool is_window_dc = false;
+  bool is_memory_dc = false;
+  HBITMAP selected_bitmap = nullptr;
+};
+
+struct DibInfo {
+  void *bits = nullptr;
+  LONG width = 0;
+  LONG height = 0;
+  WORD bit_count = 0;
+  DWORD compression = 0;
+  LONG pitch = 0;
+  bool top_down = false;
+};
+
+struct FrameCaptureState {
+  bool active = false;
+  int width = 0;
+  int height = 0;
+  uint64_t generation = 0;
+  uint64_t last_consumed_generation = 0;
+  std::vector<uint8_t> rgba;
+};
+
+std::mutex g_state_mutex;
+std::mutex g_hook_mutex;
+
+std::unordered_map<HWND, WindowInfo> g_windows;
+std::unordered_map<HDC, DcInfo> g_dcs;
+std::unordered_map<HBITMAP, DibInfo> g_dibs;
+std::unordered_set<HMODULE> g_hooked_modules;
+FrameCaptureState g_capture_state;
+
+std::wstring SafeWideString(LPCWSTR text) {
+  if (text == nullptr) {
+    return L"(null)";
+  }
+  return std::wstring(text);
+}
+
+std::wstring ConvertAnsiToWide(const char *text) {
+  if (text == nullptr) {
+    return L"(null)";
+  }
+  const int length = static_cast<int>(std::strlen(text));
+  if (length == 0) {
+    return std::wstring();
+  }
+  const int chars_needed =
+      MultiByteToWideChar(CP_ACP, 0, text, length, nullptr, 0);
+  if (chars_needed <= 0) {
+    return L"(conversion failed)";
+  }
+  std::wstring wide(static_cast<size_t>(chars_needed), L'\0');
+  const int converted = MultiByteToWideChar(CP_ACP, 0, text, length,
+                                            wide.data(), chars_needed);
+  if (converted <= 0) {
+    return L"(conversion failed)";
+  }
+  return wide;
+}
+
+void LogTimestampPrefix(FILE *file) {
+  SYSTEMTIME st;
+  GetLocalTime(&st);
+  std::fwprintf(file, L"[%04u-%02u-%02u %02u:%02u:%02u.%03u] ", st.wYear,
+                st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond,
+                st.wMilliseconds);
+}
+
+FARPROC ResolveOriginal(const char *module_name, const char *function_name) {
+  HMODULE module = GetModuleHandleA(module_name);
+  if (module == nullptr) {
+    module = LoadLibraryA(module_name);
+  }
+  if (module == nullptr) {
+    return nullptr;
+  }
+  return GetProcAddress(module, function_name);
+}
+
+void LogLocked(const wchar_t *format, va_list args) {
+  if (!g_logger.initialized || g_logger.file == nullptr) {
+    return;
+  }
+  LogTimestampPrefix(g_logger.file);
+  std::vfwprintf(g_logger.file, format, args);
+  std::fputwc(L'\n', g_logger.file);
+  std::fflush(g_logger.file);
+}
+
+void LogUnlocked(const wchar_t *format, ...) {
+  std::lock_guard<std::mutex> lock(g_logger.mutex);
+  va_list args;
+  va_start(args, format);
+  LogLocked(format, args);
+  va_end(args);
+}
+
+void RememberWindow(HWND hwnd, const WindowInfo &info) {
+  std::lock_guard<std::mutex> state_lock(g_state_mutex);
+  g_windows[hwnd] = info;
+}
+
+void ForgetWindow(HWND hwnd) {
+  std::lock_guard<std::mutex> state_lock(g_state_mutex);
+  g_windows.erase(hwnd);
+}
+
+void RememberDc(HDC dc, const DcInfo &info) {
+  std::lock_guard<std::mutex> state_lock(g_state_mutex);
+  g_dcs[dc] = info;
+}
+
+void ForgetDc(HDC dc) {
+  std::lock_guard<std::mutex> state_lock(g_state_mutex);
+  g_dcs.erase(dc);
+}
+
+void UpdateDcSelection(HDC dc, HBITMAP bitmap) {
+  std::lock_guard<std::mutex> state_lock(g_state_mutex);
+  auto it = g_dcs.find(dc);
+  if (it != g_dcs.end()) {
+    it->second.selected_bitmap = bitmap;
+  }
+}
+
+void RememberDib(HBITMAP bitmap, const DibInfo &info) {
+  std::lock_guard<std::mutex> state_lock(g_state_mutex);
+  g_dibs[bitmap] = info;
+}
+
+void ForgetDib(HBITMAP bitmap) {
+  std::lock_guard<std::mutex> state_lock(g_state_mutex);
+  g_dibs.erase(bitmap);
+}
+
+bool CaptureFromDcLocked(HDC dc, int width, int height) {
+  if (!g_capture_state.active || width != g_capture_state.width ||
+      height != g_capture_state.height) {
+    return false;
+  }
+  auto dc_it = g_dcs.find(dc);
+  if (dc_it == g_dcs.end()) {
+    return false;
+  }
+  const HBITMAP selected = dc_it->second.selected_bitmap;
+  if (selected == nullptr) {
+    return false;
+  }
+  auto dib_it = g_dibs.find(selected);
+  if (dib_it == g_dibs.end()) {
+    return false;
+  }
+  const DibInfo &dib = dib_it->second;
+  if (dib.bit_count != 32 || dib.width != width || dib.height != height ||
+      dib.bits == nullptr) {
+    return false;
+  }
+
+  const uint8_t *src_bytes =
+      reinterpret_cast<const uint8_t *>(dib.bits);
+  const size_t row_bytes = static_cast<size_t>(width) * 4;
+  const size_t total_bytes = row_bytes * static_cast<size_t>(height);
+  g_capture_state.rgba.resize(total_bytes);
+  for (int y = 0; y < height; ++y) {
+    const int src_y = dib.top_down ? y : (height - 1 - y);
+    const uint8_t *src_row = src_bytes + static_cast<size_t>(src_y) *
+                                           static_cast<size_t>(dib.pitch);
+    uint8_t *dst_row = g_capture_state.rgba.data() +
+                       static_cast<size_t>(y) * row_bytes;
+    for (int x = 0; x < width; ++x) {
+      const size_t offset = static_cast<size_t>(x) * 4;
+      dst_row[offset + 0] = src_row[offset + 2];
+      dst_row[offset + 1] = src_row[offset + 1];
+      dst_row[offset + 2] = src_row[offset + 0];
+      dst_row[offset + 3] = src_row[offset + 3];
+    }
+  }
+
+  g_capture_state.generation++;
+  return true;
+}
+
+bool TryCaptureFromBitBlt(HDC dest, HDC src, int width, int height) {
+  std::lock_guard<std::mutex> state_lock(g_state_mutex);
+  const bool from_src = CaptureFromDcLocked(src, width, height);
+  const bool from_dest = from_src ? false : CaptureFromDcLocked(dest, width, height);
+  return from_src || from_dest;
+}
+
+using CreateWindowExWFunc =
+    HWND(WINAPI *)(DWORD, LPCWSTR, LPCWSTR, DWORD, int, int, int, int, HWND,
+                   HMENU, HINSTANCE, LPVOID);
+
+HWND WINAPI HookCreateWindowExW(DWORD dwExStyle, LPCWSTR lpClassName,
+                                LPCWSTR lpWindowName, DWORD dwStyle, int X,
+                                int Y, int nWidth, int nHeight, HWND hWndParent,
+                                HMENU hMenu, HINSTANCE hInstance,
+                                LPVOID lpParam) {
+  auto original = reinterpret_cast<CreateWindowExWFunc>(
+      ResolveOriginal("USER32.dll", "CreateWindowExW"));
+  LogUnlocked(L"CreateWindowExW class='%ls' title='%ls' ex=0x%08X style=0x%08X parent=%p",
+              lpClassName ? lpClassName : L"(null)",
+              lpWindowName ? lpWindowName : L"(null)", dwExStyle, dwStyle,
+              hWndParent);
+  HWND hwnd = nullptr;
+  if (original != nullptr) {
+    hwnd = original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth,
+                    nHeight, hWndParent, hMenu, hInstance, lpParam);
+  }
+  LogUnlocked(L"CreateWindowExW => %p", hwnd);
+  if (hwnd != nullptr) {
+    WindowInfo info;
+    info.class_name = SafeWideString(lpClassName);
+    info.title = SafeWideString(lpWindowName);
+    info.style = dwStyle;
+    info.ex_style = dwExStyle;
+    info.parent = hWndParent;
+    RememberWindow(hwnd, info);
+  }
+  return hwnd;
+}
+
+using CreateWindowExAFunc =
+    HWND(WINAPI *)(DWORD, LPCSTR, LPCSTR, DWORD, int, int, int, int, HWND,
+                   HMENU, HINSTANCE, LPVOID);
+
+HWND WINAPI HookCreateWindowExA(DWORD dwExStyle, LPCSTR lpClassName,
+                                LPCSTR lpWindowName, DWORD dwStyle, int X,
+                                int Y, int nWidth, int nHeight, HWND hWndParent,
+                                HMENU hMenu, HINSTANCE hInstance,
+                                LPVOID lpParam) {
+  auto original = reinterpret_cast<CreateWindowExAFunc>(
+      ResolveOriginal("USER32.dll", "CreateWindowExA"));
+  std::wstring class_name = ConvertAnsiToWide(lpClassName);
+  std::wstring window_name = ConvertAnsiToWide(lpWindowName);
+  LogUnlocked(L"CreateWindowExA class='%ls' title='%ls' ex=0x%08X style=0x%08X parent=%p",
+              class_name.c_str(), window_name.c_str(), dwExStyle, dwStyle,
+              hWndParent);
+  HWND hwnd = nullptr;
+  if (original != nullptr) {
+    hwnd = original(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth,
+                    nHeight, hWndParent, hMenu, hInstance, lpParam);
+  }
+  LogUnlocked(L"CreateWindowExA => %p", hwnd);
+  if (hwnd != nullptr) {
+    WindowInfo info;
+    info.class_name = class_name;
+    info.title = window_name;
+    info.style = dwStyle;
+    info.ex_style = dwExStyle;
+    info.parent = hWndParent;
+    RememberWindow(hwnd, info);
+  }
+  return hwnd;
+}
+
+using DestroyWindowFunc = BOOL(WINAPI *)(HWND);
+
+BOOL WINAPI HookDestroyWindow(HWND hwnd) {
+  auto original =
+      reinterpret_cast<DestroyWindowFunc>(ResolveOriginal("USER32.dll", "DestroyWindow"));
+  LogUnlocked(L"DestroyWindow hwnd=%p", hwnd);
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(hwnd);
+  }
+  if (result) {
+    ForgetWindow(hwnd);
+  }
+  return result;
+}
+
+using GetDCFunc = HDC(WINAPI *)(HWND);
+
+HDC WINAPI HookGetDC(HWND hwnd) {
+  auto original = reinterpret_cast<GetDCFunc>(ResolveOriginal("USER32.dll", "GetDC"));
+  HDC dc = nullptr;
+  if (original != nullptr) {
+    dc = original(hwnd);
+  }
+  LogUnlocked(L"GetDC hwnd=%p => %p", hwnd, dc);
+  if (dc != nullptr) {
+    DcInfo info;
+    info.owner = hwnd;
+    info.is_window_dc = true;
+    RememberDc(dc, info);
+  }
+  return dc;
+}
+
+using GetWindowDCFunc = HDC(WINAPI *)(HWND);
+
+HDC WINAPI HookGetWindowDC(HWND hwnd) {
+  auto original = reinterpret_cast<GetWindowDCFunc>(
+      ResolveOriginal("USER32.dll", "GetWindowDC"));
+  HDC dc = nullptr;
+  if (original != nullptr) {
+    dc = original(hwnd);
+  }
+  LogUnlocked(L"GetWindowDC hwnd=%p => %p", hwnd, dc);
+  if (dc != nullptr) {
+    DcInfo info;
+    info.owner = hwnd;
+    info.is_window_dc = true;
+    RememberDc(dc, info);
+  }
+  return dc;
+}
+
+using ReleaseDCFunc = int(WINAPI *)(HWND, HDC);
+
+int WINAPI HookReleaseDC(HWND hwnd, HDC dc) {
+  auto original = reinterpret_cast<ReleaseDCFunc>(
+      ResolveOriginal("USER32.dll", "ReleaseDC"));
+  int result = 0;
+  if (original != nullptr) {
+    result = original(hwnd, dc);
+  }
+  LogUnlocked(L"ReleaseDC hwnd=%p dc=%p => %d", hwnd, dc, result);
+  if (result == 1) {
+    ForgetDc(dc);
+  }
+  return result;
+}
+
+using CreateCompatibleDCFunc = HDC(WINAPI *)(HDC);
+
+HDC WINAPI HookCreateCompatibleDC(HDC dc) {
+  auto original = reinterpret_cast<CreateCompatibleDCFunc>(
+      ResolveOriginal("GDI32.dll", "CreateCompatibleDC"));
+  HDC new_dc = nullptr;
+  if (original != nullptr) {
+    new_dc = original(dc);
+  }
+  LogUnlocked(L"CreateCompatibleDC source=%p => %p", dc, new_dc);
+  if (new_dc != nullptr) {
+    DcInfo info;
+    info.owner = nullptr;
+    info.is_memory_dc = true;
+    RememberDc(new_dc, info);
+  }
+  return new_dc;
+}
+
+using DeleteDCFunc = BOOL(WINAPI *)(HDC);
+
+BOOL WINAPI HookDeleteDC(HDC dc) {
+  auto original =
+      reinterpret_cast<DeleteDCFunc>(ResolveOriginal("GDI32.dll", "DeleteDC"));
+  LogUnlocked(L"DeleteDC %p", dc);
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(dc);
+  }
+  if (result) {
+    ForgetDc(dc);
+  }
+  return result;
+}
+
+using CreateDIBSectionFunc = HBITMAP(WINAPI *)(HDC, const BITMAPINFO *, UINT,
+                                               void **, HANDLE, DWORD);
+
+HBITMAP WINAPI HookCreateDIBSection(HDC dc, const BITMAPINFO *bmi, UINT usage,
+                                    void **bits, HANDLE section, DWORD offset) {
+  auto original = reinterpret_cast<CreateDIBSectionFunc>(
+      ResolveOriginal("GDI32.dll", "CreateDIBSection"));
+  HBITMAP bitmap = nullptr;
+  if (original != nullptr) {
+    bitmap = original(dc, bmi, usage, bits, section, offset);
+  }
+  if (bmi != nullptr) {
+    const BITMAPINFOHEADER &hdr = bmi->bmiHeader;
+    LogUnlocked(L"CreateDIBSection dc=%p %ldx%ld bitCount=%d compression=%u => %p bits=%p",
+                dc, hdr.biWidth, hdr.biHeight, hdr.biBitCount, hdr.biCompression,
+                bitmap, bits ? *bits : nullptr);
+    if (bitmap != nullptr && bits != nullptr && *bits != nullptr) {
+      DibInfo info;
+      info.bits = *bits;
+      info.width = std::abs(hdr.biWidth);
+      info.height = std::abs(hdr.biHeight);
+      info.bit_count = hdr.biBitCount;
+      info.compression = hdr.biCompression;
+      info.top_down = hdr.biHeight < 0;
+      const int bytes_per_pixel = hdr.biBitCount / 8;
+      const int stride_bits = hdr.biWidth * hdr.biBitCount;
+      const int stride_bytes = ((stride_bits + 31) / 32) * 4;
+      info.pitch = stride_bytes;
+      RememberDib(bitmap, info);
+    }
+  } else {
+    LogUnlocked(L"CreateDIBSection dc=%p => %p (no BMI)", dc, bitmap);
+  }
+  return bitmap;
+}
+
+using DeleteObjectFunc = BOOL(WINAPI *)(HGDIOBJ);
+
+BOOL WINAPI HookDeleteObject(HGDIOBJ object) {
+  auto original = reinterpret_cast<DeleteObjectFunc>(
+      ResolveOriginal("GDI32.dll", "DeleteObject"));
+  LogUnlocked(L"DeleteObject %p", object);
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(object);
+  }
+  if (result) {
+    ForgetDib(static_cast<HBITMAP>(object));
+  }
+  return result;
+}
+
+using SelectObjectFunc = HGDIOBJ(WINAPI *)(HDC, HGDIOBJ);
+
+HGDIOBJ WINAPI HookSelectObject(HDC dc, HGDIOBJ object) {
+  auto original = reinterpret_cast<SelectObjectFunc>(
+      ResolveOriginal("GDI32.dll", "SelectObject"));
+  HGDIOBJ previous = nullptr;
+  if (original != nullptr) {
+    previous = original(dc, object);
+  }
+  LogUnlocked(L"SelectObject dc=%p object=%p => %p", dc, object, previous);
+  if (object != nullptr) {
+    UpdateDcSelection(dc, static_cast<HBITMAP>(object));
+  }
+  return previous;
+}
+
+using BitBltFunc = BOOL(WINAPI *)(HDC, int, int, int, int, HDC, int, int, DWORD);
+
+BOOL WINAPI HookBitBlt(HDC dest, int x_dest, int y_dest, int width, int height,
+                       HDC src, int x_src, int y_src, DWORD rop) {
+  auto original = reinterpret_cast<BitBltFunc>(
+      ResolveOriginal("GDI32.dll", "BitBlt"));
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(dest, x_dest, y_dest, width, height, src, x_src, y_src,
+                      rop);
+  }
+  const bool captured = TryCaptureFromBitBlt(dest, src, width, height);
+  LogUnlocked(L"BitBlt dest=%p src=%p size=%dx%d rop=0x%08lX => %d%s",
+              dest, src, width, height, rop, result,
+              captured ? L" [captured]" : L"");
+  return result;
+}
+
+using StretchBltFunc = BOOL(WINAPI *)(HDC, int, int, int, int, HDC, int, int,
+                                      int, int, DWORD);
+
+BOOL WINAPI HookStretchBlt(HDC dest, int x_dest, int y_dest, int width,
+                           int height, HDC src, int x_src, int y_src,
+                           int src_width, int src_height, DWORD rop) {
+  auto original = reinterpret_cast<StretchBltFunc>(
+      ResolveOriginal("GDI32.dll", "StretchBlt"));
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(dest, x_dest, y_dest, width, height, src, x_src, y_src,
+                      src_width, src_height, rop);
+  }
+  const bool captured = TryCaptureFromBitBlt(dest, src, width, height);
+  LogUnlocked(L"StretchBlt dest=%p src=%p size=%dx%d rop=0x%08lX => %d%s",
+              dest, src, width, height, rop, result,
+              captured ? L" [captured]" : L"");
+  return result;
+}
+
+using SwapBuffersFunc = BOOL(WINAPI *)(HDC);
+
+BOOL WINAPI HookSwapBuffers(HDC dc) {
+  auto original = reinterpret_cast<SwapBuffersFunc>(
+      ResolveOriginal("GDI32.dll", "SwapBuffers"));
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(dc);
+  }
+  LogUnlocked(L"SwapBuffers dc=%p => %d", dc, result);
+  return result;
+}
+
+using WglCreateContextFunc = HGLRC(WINAPI *)(HDC);
+
+HGLRC WINAPI HookWglCreateContext(HDC dc) {
+  auto original = reinterpret_cast<WglCreateContextFunc>(
+      ResolveOriginal("OPENGL32.dll", "wglCreateContext"));
+  HGLRC ctx = nullptr;
+  if (original != nullptr) {
+    ctx = original(dc);
+  }
+  LogUnlocked(L"wglCreateContext dc=%p => %p", dc, ctx);
+  return ctx;
+}
+
+using WglMakeCurrentFunc = BOOL(WINAPI *)(HDC, HGLRC);
+
+BOOL WINAPI HookWglMakeCurrent(HDC dc, HGLRC ctx) {
+  auto original = reinterpret_cast<WglMakeCurrentFunc>(
+      ResolveOriginal("OPENGL32.dll", "wglMakeCurrent"));
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(dc, ctx);
+  }
+  LogUnlocked(L"wglMakeCurrent dc=%p ctx=%p => %d", dc, ctx, result);
+  return result;
+}
+
+using WglDeleteContextFunc = BOOL(WINAPI *)(HGLRC);
+
+BOOL WINAPI HookWglDeleteContext(HGLRC ctx) {
+  auto original = reinterpret_cast<WglDeleteContextFunc>(
+      ResolveOriginal("OPENGL32.dll", "wglDeleteContext"));
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(ctx);
+  }
+  LogUnlocked(L"wglDeleteContext ctx=%p => %d", ctx, result);
+  return result;
+}
+
+using WglSwapLayerBuffersFunc = BOOL(WINAPI *)(HDC, UINT);
+
+BOOL WINAPI HookWglSwapLayerBuffers(HDC dc, UINT planes) {
+  auto original = reinterpret_cast<WglSwapLayerBuffersFunc>(
+      ResolveOriginal("OPENGL32.dll", "wglSwapLayerBuffers"));
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(dc, planes);
+  }
+  LogUnlocked(L"wglSwapLayerBuffers dc=%p planes=0x%X => %d", dc, planes,
+              result);
+  return result;
+}
+
+using BeginPaintFunc = HDC(WINAPI *)(HWND, LPPAINTSTRUCT);
+
+HDC WINAPI HookBeginPaint(HWND hwnd, LPPAINTSTRUCT ps) {
+  auto original = reinterpret_cast<BeginPaintFunc>(
+      ResolveOriginal("USER32.dll", "BeginPaint"));
+  HDC dc = nullptr;
+  if (original != nullptr) {
+    dc = original(hwnd, ps);
+  }
+  LogUnlocked(L"BeginPaint hwnd=%p => %p", hwnd, dc);
+  if (dc != nullptr) {
+    DcInfo info;
+    info.owner = hwnd;
+    info.is_window_dc = true;
+    RememberDc(dc, info);
+  }
+  return dc;
+}
+
+using EndPaintFunc = BOOL(WINAPI *)(HWND, const PAINTSTRUCT *);
+
+BOOL WINAPI HookEndPaint(HWND hwnd, const PAINTSTRUCT *ps) {
+  auto original = reinterpret_cast<EndPaintFunc>(
+      ResolveOriginal("USER32.dll", "EndPaint"));
+  BOOL result = FALSE;
+  if (original != nullptr) {
+    result = original(hwnd, ps);
+  }
+  LogUnlocked(L"EndPaint hwnd=%p => %d", hwnd, result);
+  return result;
+}
+
+struct ApiHookSpec {
+  const char *dll_name;
+  const char *function_name;
+  FARPROC replacement;
+};
+
+const ApiHookSpec kHookSpecs[] = {
+    {"USER32.dll", "CreateWindowExW",
+     reinterpret_cast<FARPROC>(&HookCreateWindowExW)},
+    {"USER32.dll", "CreateWindowExA",
+     reinterpret_cast<FARPROC>(&HookCreateWindowExA)},
+    {"USER32.dll", "DestroyWindow",
+     reinterpret_cast<FARPROC>(&HookDestroyWindow)},
+    {"USER32.dll", "GetDC", reinterpret_cast<FARPROC>(&HookGetDC)},
+    {"USER32.dll", "GetWindowDC", reinterpret_cast<FARPROC>(&HookGetWindowDC)},
+    {"USER32.dll", "ReleaseDC", reinterpret_cast<FARPROC>(&HookReleaseDC)},
+    {"USER32.dll", "BeginPaint", reinterpret_cast<FARPROC>(&HookBeginPaint)},
+    {"USER32.dll", "EndPaint", reinterpret_cast<FARPROC>(&HookEndPaint)},
+    {"GDI32.dll", "CreateCompatibleDC",
+     reinterpret_cast<FARPROC>(&HookCreateCompatibleDC)},
+    {"GDI32.dll", "DeleteDC", reinterpret_cast<FARPROC>(&HookDeleteDC)},
+    {"GDI32.dll", "CreateDIBSection",
+     reinterpret_cast<FARPROC>(&HookCreateDIBSection)},
+    {"GDI32.dll", "DeleteObject",
+     reinterpret_cast<FARPROC>(&HookDeleteObject)},
+    {"GDI32.dll", "SelectObject",
+     reinterpret_cast<FARPROC>(&HookSelectObject)},
+    {"GDI32.dll", "BitBlt", reinterpret_cast<FARPROC>(&HookBitBlt)},
+    {"GDI32.dll", "StretchBlt", reinterpret_cast<FARPROC>(&HookStretchBlt)},
+    {"GDI32.dll", "SwapBuffers", reinterpret_cast<FARPROC>(&HookSwapBuffers)},
+    {"OPENGL32.dll", "wglCreateContext",
+     reinterpret_cast<FARPROC>(&HookWglCreateContext)},
+    {"OPENGL32.dll", "wglMakeCurrent",
+     reinterpret_cast<FARPROC>(&HookWglMakeCurrent)},
+    {"OPENGL32.dll", "wglDeleteContext",
+     reinterpret_cast<FARPROC>(&HookWglDeleteContext)},
+    {"OPENGL32.dll", "wglSwapLayerBuffers",
+     reinterpret_cast<FARPROC>(&HookWglSwapLayerBuffers)},
+};
+
+bool EqualsIgnoreCase(const char *a, const char *b) {
+  return _stricmp(a, b) == 0;
+}
+
+void PatchImport(HMODULE module, const ApiHookSpec &spec) {
+  BYTE *base = reinterpret_cast<BYTE *>(module);
+  const IMAGE_DOS_HEADER *dos = reinterpret_cast<const IMAGE_DOS_HEADER *>(base);
+  if (dos->e_magic != IMAGE_DOS_SIGNATURE) {
+    return;
+  }
+  const IMAGE_NT_HEADERS *nt =
+      reinterpret_cast<const IMAGE_NT_HEADERS *>(base + dos->e_lfanew);
+  const IMAGE_DATA_DIRECTORY &dir =
+      nt->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
+  if (dir.VirtualAddress == 0) {
+    return;
+  }
+  auto import_desc = reinterpret_cast<IMAGE_IMPORT_DESCRIPTOR *>(
+      base + dir.VirtualAddress);
+  for (; import_desc->Name != 0; ++import_desc) {
+    const char *dll_name =
+        reinterpret_cast<const char *>(base + import_desc->Name);
+    if (dll_name == nullptr || !EqualsIgnoreCase(dll_name, spec.dll_name)) {
+      continue;
+    }
+    auto thunk = reinterpret_cast<IMAGE_THUNK_DATA *>(
+        base + import_desc->FirstThunk);
+    auto orig_thunk = reinterpret_cast<IMAGE_THUNK_DATA *>(
+        base + (import_desc->OriginalFirstThunk != 0
+                    ? import_desc->OriginalFirstThunk
+                    : import_desc->FirstThunk));
+    for (; orig_thunk->u1.AddressOfData != 0; ++orig_thunk, ++thunk) {
+      if (IMAGE_SNAP_BY_ORDINAL(orig_thunk->u1.Ordinal)) {
+        continue;
+      }
+      auto import_name = reinterpret_cast<IMAGE_IMPORT_BY_NAME *>(
+          base + orig_thunk->u1.AddressOfData);
+      if (import_name == nullptr || import_name->Name[0] == '\0') {
+        continue;
+      }
+      if (!EqualsIgnoreCase(reinterpret_cast<char *>(import_name->Name),
+                            spec.function_name)) {
+        continue;
+      }
+      DWORD old_protect = 0;
+      if (VirtualProtect(&thunk->u1.Function, sizeof(void *),
+                         PAGE_EXECUTE_READWRITE, &old_protect)) {
+        thunk->u1.Function = reinterpret_cast<ULONG_PTR>(spec.replacement);
+        VirtualProtect(&thunk->u1.Function, sizeof(void *), old_protect,
+                       &old_protect);
+        LogUnlocked(L"Patched %hs!%hs in module %p",
+                    spec.dll_name, spec.function_name, module);
+      }
+    }
+  }
+}
+
+} // namespace
+
+void Initialize(const std::wstring &log_path) {
+  std::lock_guard<std::mutex> lock(g_logger.mutex);
+  if (g_logger.file != nullptr) {
+    std::fclose(g_logger.file);
+    g_logger.file = nullptr;
+  }
+  g_logger.file = _wfopen(log_path.c_str(), L"w, ccs=UTF-8");
+  if (g_logger.file == nullptr) {
+    g_logger.initialized = false;
+    return;
+  }
+  g_logger.initialized = true;
+  LogTimestampPrefix(g_logger.file);
+  std::fwprintf(g_logger.file, L"Diagnostics log initialized at %ls\n",
+                log_path.c_str());
+  std::fflush(g_logger.file);
+}
+
+void Shutdown() {
+  std::lock_guard<std::mutex> lock(g_logger.mutex);
+  if (g_logger.file != nullptr) {
+    std::fclose(g_logger.file);
+    g_logger.file = nullptr;
+  }
+  g_logger.initialized = false;
+}
+
+void InstallForCurrentProcess() {
+  InstallForModule(GetModuleHandleW(nullptr));
+}
+
+void InstallForModule(HMODULE module) {
+  if (module == nullptr) {
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lock(g_hook_mutex);
+    if (!g_hooked_modules.insert(module).second) {
+      return;
+    }
+  }
+  for (const auto &spec : kHookSpecs) {
+    PatchImport(module, spec);
+  }
+}
+
+void RegisterWindowTag(HWND hwnd, const std::wstring &tag) {
+  {
+    std::lock_guard<std::mutex> lock(g_state_mutex);
+    WindowInfo &info = g_windows[hwnd];
+    info.tag = tag;
+  }
+  LogUnlocked(L"Registered tag '%ls' for hwnd=%p", tag.c_str(), hwnd);
+}
+
+void SetCaptureBounds(int width, int height) {
+  bool active = (width > 0 && height > 0);
+  {
+    std::lock_guard<std::mutex> lock(g_state_mutex);
+    g_capture_state.active = active;
+    g_capture_state.width = width;
+    g_capture_state.height = height;
+    g_capture_state.generation = 0;
+    g_capture_state.last_consumed_generation = 0;
+    g_capture_state.rgba.clear();
+  }
+  LogUnlocked(L"Configured capture bounds %dx%d (active=%d)", width, height,
+              active ? 1 : 0);
+}
+
+bool FetchLastFrame(std::vector<uint8_t> &rgba, uint64_t &frame_index) {
+  std::lock_guard<std::mutex> lock(g_state_mutex);
+  if (!g_capture_state.active ||
+      g_capture_state.generation == g_capture_state.last_consumed_generation ||
+      g_capture_state.rgba.empty()) {
+    return false;
+  }
+  rgba = g_capture_state.rgba;
+  frame_index = g_capture_state.generation;
+  g_capture_state.last_consumed_generation = g_capture_state.generation;
+  return true;
+}
+
+void Logf(const wchar_t *format, ...) {
+  std::lock_guard<std::mutex> lock(g_logger.mutex);
+  if (!g_logger.initialized || g_logger.file == nullptr) {
+    return;
+  }
+  va_list args;
+  va_start(args, format);
+  LogLocked(format, args);
+  va_end(args);
+}
+
+} // namespace diagnostics
+
+#endif // defined(_WIN32)
+

--- a/tools/windows_diagnostics.hpp
+++ b/tools/windows_diagnostics.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+
+namespace diagnostics {
+
+void Initialize(const std::wstring &log_path);
+void Shutdown();
+
+void InstallForCurrentProcess();
+void InstallForModule(HMODULE module);
+
+void RegisterWindowTag(HWND hwnd, const std::wstring &tag);
+void SetCaptureBounds(int width, int height);
+
+bool FetchLastFrame(std::vector<uint8_t> &rgba, uint64_t &frame_index);
+
+void Logf(const wchar_t *format, ...);
+
+} // namespace diagnostics
+
+#else // !defined(_WIN32)
+
+namespace diagnostics {
+
+inline void Initialize(const std::wstring &) {}
+inline void Shutdown() {}
+inline void InstallForCurrentProcess() {}
+inline void InstallForModule(void *) {}
+inline void RegisterWindowTag(void *, const std::wstring &) {}
+inline void SetCaptureBounds(int, int) {}
+inline bool FetchLastFrame(std::vector<uint8_t> &, uint64_t &) { return false; }
+inline void Logf(const wchar_t *, ...) {}
+
+} // namespace diagnostics
+
+#endif // defined(_WIN32)
+


### PR DESCRIPTION
## Summary
- add a diagnostics subsystem that hooks core User32/Gdi32/OpenGL entry points to log HWND/HDC usage, DIB creation, and BitBlt activity while caching captured frames for later recovery
- wire diagnostics into generate-verification-data so runs emit a timestamped diagnostics.log, install hooks before loading vis_avs.dll, and fall back to captured DIB frames when window capture fails
- enrich vis_host lifecycle logging to record DLL load/unload and Init/Quit transitions, and ensure new module is built via CMake

## Testing
- not run (Windows-only components)


------
https://chatgpt.com/codex/tasks/task_e_68e09f701350832cb1bcbbe5951b18ab