### PR TITLE
Enhance diagnostics hooks and capture fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,4 +91,4 @@ else ()
     set(VFW32_LIB vfw32)
 endif ()
 
-target_link_libraries(visdriver PRIVATE ${VFW32_LIB})
+target_link_libraries(visdriver PRIVATE ${VFW32_LIB} opengl32)

--- a/tools/capture.cpp
+++ b/tools/capture.cpp
@@ -7,6 +7,8 @@
 #include <memory>
 #include <type_traits>
 
+#include "debug_trace.hpp"
+
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb/stb_image_write.h"
 
@@ -82,14 +84,21 @@ bool capture_child_to_rgba(HWND child, int width, int height,
                            std::vector<uint8_t> &out_rgba) {
   if (child == nullptr || width <= 0 || height <= 0) {
     std::wcerr << L"ERROR: Invalid parameters for capture_child_to_rgba.\n";
+    DebugTraceLog(L"capture_child_to_rgba invalid args hwnd=%p width=%d height=%d",
+                  child, width, height);
     return false;
   }
+
+  DebugTraceLog(L"capture_child_to_rgba(hwnd=%p, width=%d, height=%d)", child, width,
+                height);
 
   unique_window_dc window_dc(GetDC(child), WindowDcDeleter{child});
   if (!window_dc) {
     const DWORD error = GetLastError();
     std::wcerr << L"ERROR: GetDC failed: "
                << FormatWindowsErrorMessage(error) << L"\n";
+    DebugTraceLog(L"capture_child_to_rgba: GetDC failed hwnd=%p error=%lu", child,
+                  error);
     return false;
   }
 
@@ -98,6 +107,8 @@ bool capture_child_to_rgba(HWND child, int width, int height,
     const DWORD error = GetLastError();
     std::wcerr << L"ERROR: CreateCompatibleDC failed: "
                << FormatWindowsErrorMessage(error) << L"\n";
+    DebugTraceLog(L"capture_child_to_rgba: CreateCompatibleDC failed hwnd=%p error=%lu",
+                  child, error);
     return false;
   }
 
@@ -117,6 +128,8 @@ bool capture_child_to_rgba(HWND child, int width, int height,
     const DWORD error = GetLastError();
     std::wcerr << L"ERROR: CreateDIBSection failed: "
                << FormatWindowsErrorMessage(error) << L"\n";
+    DebugTraceLog(L"capture_child_to_rgba: CreateDIBSection failed hwnd=%p error=%lu",
+                  child, error);
     return false;
   }
 
@@ -125,6 +138,8 @@ bool capture_child_to_rgba(HWND child, int width, int height,
     const DWORD error = GetLastError();
     std::wcerr << L"ERROR: SelectObject failed: "
                << FormatWindowsErrorMessage(error) << L"\n";
+    DebugTraceLog(L"capture_child_to_rgba: SelectObject failed hwnd=%p error=%lu",
+                  child, error);
     return false;
   }
 
@@ -135,6 +150,8 @@ bool capture_child_to_rgba(HWND child, int width, int height,
     SelectObject(memory_dc.get(), old_bitmap);
     std::wcerr << L"ERROR: BitBlt failed: "
                << FormatWindowsErrorMessage(error) << L"\n";
+    DebugTraceLog(L"capture_child_to_rgba: BitBlt failed hwnd=%p error=%lu", child,
+                  error);
     return false;
   }
 
@@ -152,6 +169,7 @@ bool capture_child_to_rgba(HWND child, int width, int height,
   }
 
   SelectObject(memory_dc.get(), old_bitmap);
+  DebugTraceLog(L"capture_child_to_rgba: success hwnd=%p", child);
   return true;
 }
 

--- a/tools/debug_trace.cpp
+++ b/tools/debug_trace.cpp
@@ -23,6 +23,10 @@ namespace {
 struct HandleInfo {
   std::wstring type;
   std::wstring detail;
+  HWND hwnd = nullptr;
+  int width = 0;
+  int height = 0;
+  void *bits = nullptr;
 };
 
 std::mutex g_log_mutex;
@@ -31,6 +35,7 @@ std::atomic<bool> g_log_initialized{false};
 
 std::mutex g_handle_mutex;
 std::unordered_map<UINT_PTR, HandleInfo> g_handle_info;
+std::unordered_map<HDC, HBITMAP> g_selected_bitmaps;
 
 std::mutex g_target_mutex;
 std::unordered_set<HWND> g_target_windows;
@@ -46,6 +51,19 @@ struct OffscreenSurface {
 
 std::mutex g_surface_mutex;
 OffscreenSurface g_offscreen_surface;
+
+struct DiagnosticsBuffer {
+  HDC dc = nullptr;
+  HBITMAP bitmap = nullptr;
+  HBITMAP old_bitmap = nullptr;
+  void *bits = nullptr;
+  int width = 0;
+  int height = 0;
+  uint64_t generation = 0;
+};
+
+std::mutex g_diagnostics_mutex;
+DiagnosticsBuffer g_diagnostics_buffer;
 
 std::mutex g_hook_mutex;
 std::unordered_set<HMODULE> g_hooked_modules;
@@ -116,10 +134,12 @@ std::wstring FormatWide(const wchar_t *text) {
 std::wstring GetTimestamp() {
   SYSTEMTIME st;
   GetLocalTime(&st);
-  wchar_t buffer[64];
-  std::swprintf(buffer, std::size(buffer), L"%04d-%02d-%02d %02d:%02d:%02d.%03d",
-                st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond,
-                st.wMilliseconds);
+  wchar_t buffer[96];
+  const DWORD thread_id = GetCurrentThreadId();
+  std::swprintf(buffer, std::size(buffer),
+                L"%04d-%02d-%02d %02d:%02d:%02d.%03d [tid=%lu]", st.wYear,
+                st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond,
+                st.wMilliseconds, static_cast<unsigned long>(thread_id));
   return buffer;
 }
 
@@ -146,14 +166,23 @@ void WriteLogLineUnlocked(const std::wstring &line) {
 }
 
 void TrackHandle(UINT_PTR value, const std::wstring &type,
-                 const std::wstring &detail) {
+                 const std::wstring &detail, HWND hwnd = nullptr,
+                 int width = 0, int height = 0, void *bits = nullptr) {
   std::lock_guard<std::mutex> lock(g_handle_mutex);
-  g_handle_info[value] = HandleInfo{type, detail};
+  g_handle_info[value] = HandleInfo{type, detail, hwnd, width, height, bits};
 }
 
 void UntrackHandle(UINT_PTR value) {
   std::lock_guard<std::mutex> lock(g_handle_mutex);
-  g_handle_info.erase(value);
+  auto it = g_handle_info.find(value);
+  if (it != g_handle_info.end()) {
+    if (it->second.type == L"HDC") {
+      g_selected_bitmaps.erase(reinterpret_cast<HDC>(value));
+    }
+    g_handle_info.erase(it);
+  } else {
+    g_selected_bitmaps.erase(reinterpret_cast<HDC>(value));
+  }
 }
 
 std::wstring DescribeHandle(UINT_PTR value) {
@@ -169,6 +198,20 @@ std::wstring DescribeHandle(UINT_PTR value) {
     result += L" (";
     result += it->second.detail;
     result += L")";
+  }
+  if (it->second.hwnd != nullptr) {
+    result += L" hwnd=";
+    result += FormatHwnd(it->second.hwnd);
+  }
+  if (it->second.width > 0 && it->second.height > 0) {
+    result += L" size=";
+    result += std::to_wstring(it->second.width);
+    result.push_back(L'x');
+    result += std::to_wstring(it->second.height);
+  }
+  if (it->second.bits != nullptr) {
+    result += L" bits=";
+    result += FormatPointer(reinterpret_cast<UINT_PTR>(it->second.bits));
   }
   return result;
 }
@@ -190,11 +233,34 @@ bool HasOffscreenSurface() {
   return HasOffscreenSurfaceUnlocked();
 }
 
+bool IsOffscreenDcUnlocked(HDC dc) {
+  return HasOffscreenSurfaceUnlocked() && dc == g_offscreen_surface.dc;
+}
+
+bool IsOffscreenDc(HDC dc) {
+  std::lock_guard<std::mutex> lock(g_surface_mutex);
+  return IsOffscreenDcUnlocked(dc);
+}
+
+bool HasDiagnosticsBufferUnlocked() {
+  return g_diagnostics_buffer.dc != nullptr && g_diagnostics_buffer.bits != nullptr &&
+         g_diagnostics_buffer.width > 0 && g_diagnostics_buffer.height > 0;
+}
+
+bool HasDiagnosticsBuffer() {
+  std::lock_guard<std::mutex> lock(g_diagnostics_mutex);
+  return HasDiagnosticsBufferUnlocked();
+}
+
+bool ShouldSnapshotDiagnostics(HDC dc);
+bool SnapshotDiagnosticsFromDc(HDC dc, const wchar_t *reason);
+
 // Forward declarations of original functions.
 decltype(&CreateWindowExW) g_orig_CreateWindowExW = CreateWindowExW;
 decltype(&CreateWindowExA) g_orig_CreateWindowExA = CreateWindowExA;
 decltype(&DestroyWindow) g_orig_DestroyWindow = DestroyWindow;
 decltype(&GetDC) g_orig_GetDC = GetDC;
+decltype(&GetDCEx) g_orig_GetDCEx = GetDCEx;
 decltype(&GetWindowDC) g_orig_GetWindowDC = GetWindowDC;
 decltype(&ReleaseDC) g_orig_ReleaseDC = ReleaseDC;
 decltype(&BeginPaint) g_orig_BeginPaint = BeginPaint;
@@ -211,6 +277,11 @@ decltype(&SetPixelFormat) g_orig_SetPixelFormat = SetPixelFormat;
 decltype(&wglCreateContext) g_orig_wglCreateContext = wglCreateContext;
 decltype(&wglMakeCurrent) g_orig_wglMakeCurrent = wglMakeCurrent;
 decltype(&wglDeleteContext) g_orig_wglDeleteContext = wglDeleteContext;
+decltype(&CreateCompatibleBitmap) g_orig_CreateCompatibleBitmap =
+    CreateCompatibleBitmap;
+decltype(&SelectObject) g_orig_SelectObject = SelectObject;
+decltype(&PatBlt) g_orig_PatBlt = PatBlt;
+decltype(&DescribePixelFormat) g_orig_DescribePixelFormat = DescribePixelFormat;
 
 template <typename... Args>
 void Logf(const wchar_t *format, Args... args) {
@@ -290,9 +361,32 @@ HDC WINAPI Hooked_GetDC(HWND hwnd) {
   if (dc != nullptr) {
     std::wstring detail = L"GetDC hwnd=";
     detail += FormatHwnd(hwnd);
-    TrackHandle(reinterpret_cast<UINT_PTR>(dc), L"HDC", detail);
+    TrackHandle(reinterpret_cast<UINT_PTR>(dc), L"HDC", detail, hwnd);
   }
   DebugTraceLog(L"GetDC(%s) -> %s", FormatHwnd(hwnd).c_str(),
+                FormatHdc(dc).c_str());
+  return dc;
+}
+
+HDC WINAPI Hooked_GetDCEx(HWND hwnd, HRGN hrgnClip, DWORD flags) {
+  if (IsTargetWindow(hwnd) && HasOffscreenSurface()) {
+    std::lock_guard<std::mutex> lock(g_surface_mutex);
+    DebugTraceLog(
+        L"GetDCEx(%s, hrgn=%s, flags=0x%08X) -> offscreen %s",
+        FormatHwnd(hwnd).c_str(),
+        FormatPointer(reinterpret_cast<UINT_PTR>(hrgnClip)).c_str(), flags,
+        FormatHdc(g_offscreen_surface.dc).c_str());
+    return g_offscreen_surface.dc;
+  }
+  HDC dc = g_orig_GetDCEx(hwnd, hrgnClip, flags);
+  if (dc != nullptr) {
+    std::wstring detail = L"GetDCEx hwnd=";
+    detail += FormatHwnd(hwnd);
+    TrackHandle(reinterpret_cast<UINT_PTR>(dc), L"HDC", detail, hwnd);
+  }
+  DebugTraceLog(L"GetDCEx(%s, hrgn=%s, flags=0x%08X) -> %s",
+                FormatHwnd(hwnd).c_str(),
+                FormatPointer(reinterpret_cast<UINT_PTR>(hrgnClip)).c_str(), flags,
                 FormatHdc(dc).c_str());
   return dc;
 }
@@ -308,7 +402,7 @@ HDC WINAPI Hooked_GetWindowDC(HWND hwnd) {
   if (dc != nullptr) {
     std::wstring detail = L"GetWindowDC hwnd=";
     detail += FormatHwnd(hwnd);
-    TrackHandle(reinterpret_cast<UINT_PTR>(dc), L"HDC", detail);
+    TrackHandle(reinterpret_cast<UINT_PTR>(dc), L"HDC", detail, hwnd);
   }
   DebugTraceLog(L"GetWindowDC(%s) -> %s", FormatHwnd(hwnd).c_str(),
                 FormatHdc(dc).c_str());
@@ -351,7 +445,7 @@ HDC WINAPI Hooked_BeginPaint(HWND hwnd, LPPAINTSTRUCT ps) {
   if (dc != nullptr) {
     std::wstring detail = L"BeginPaint hwnd=";
     detail += FormatHwnd(hwnd);
-    TrackHandle(reinterpret_cast<UINT_PTR>(dc), L"HDC", detail);
+    TrackHandle(reinterpret_cast<UINT_PTR>(dc), L"HDC", detail, hwnd);
   }
   DebugTraceLog(L"BeginPaint(%s) -> %s", FormatHwnd(hwnd).c_str(),
                 FormatHdc(dc).c_str());
@@ -399,13 +493,19 @@ HBITMAP WINAPI Hooked_CreateDIBSection(HDC dc, const BITMAPINFO *bmi,
   if (bitmap != nullptr) {
     std::wstring detail = L"CreateDIBSection dc=";
     detail += FormatHdc(dc);
+    int bitmap_width = 0;
+    int bitmap_height = 0;
     if (bmi != nullptr) {
+      bitmap_width = bmi->bmiHeader.biWidth;
+      const LONG raw_height = bmi->bmiHeader.biHeight;
+      bitmap_height = raw_height < 0 ? -raw_height : raw_height;
       detail += L" size=";
-      detail += std::to_wstring(bmi->bmiHeader.biWidth);
+      detail += std::to_wstring(bitmap_width);
       detail += L"x";
-      detail += std::to_wstring(std::abs(bmi->bmiHeader.biHeight));
+      detail += std::to_wstring(bitmap_height);
     }
-    TrackHandle(reinterpret_cast<UINT_PTR>(bitmap), L"HBITMAP", detail);
+    TrackHandle(reinterpret_cast<UINT_PTR>(bitmap), L"HBITMAP", detail, nullptr,
+                bitmap_width, bitmap_height, bits != nullptr ? *bits : nullptr);
   }
   DebugTraceLog(L"CreateDIBSection(dc=%s, usage=%u) -> %s", FormatHdc(dc).c_str(),
                 usage, FormatPointer(reinterpret_cast<UINT_PTR>(bitmap)).c_str());
@@ -419,13 +519,59 @@ BOOL WINAPI Hooked_DeleteObject(HGDIOBJ obj) {
   return g_orig_DeleteObject(obj);
 }
 
+HBITMAP WINAPI Hooked_CreateCompatibleBitmap(HDC dc, int width, int height) {
+  HBITMAP bitmap = g_orig_CreateCompatibleBitmap(dc, width, height);
+  if (bitmap != nullptr) {
+    std::wstring detail = L"CreateCompatibleBitmap dc=";
+    detail += FormatHdc(dc);
+    detail += L" size=";
+    detail += std::to_wstring(width);
+    detail += L"x";
+    detail += std::to_wstring(height);
+    TrackHandle(reinterpret_cast<UINT_PTR>(bitmap), L"HBITMAP", detail, nullptr,
+                width, height, nullptr);
+  }
+  DebugTraceLog(L"CreateCompatibleBitmap(dc=%s, %dx%d) -> %s",
+                FormatHdc(dc).c_str(), width, height,
+                FormatPointer(reinterpret_cast<UINT_PTR>(bitmap)).c_str());
+  return bitmap;
+}
+
+HGDIOBJ WINAPI Hooked_SelectObject(HDC dc, HGDIOBJ obj) {
+  HGDIOBJ previous = g_orig_SelectObject(dc, obj);
+  const UINT object_type = (obj != nullptr) ? GetObjectType(obj) : 0U;
+  {
+    std::lock_guard<std::mutex> lock(g_handle_mutex);
+    if (object_type == OBJ_BITMAP) {
+      g_selected_bitmaps[dc] = static_cast<HBITMAP>(obj);
+    } else {
+      g_selected_bitmaps.erase(dc);
+    }
+  }
+  DebugTraceLog(L"SelectObject(dc=%s, obj=%s) -> %s", FormatHdc(dc).c_str(),
+                DescribeHandle(reinterpret_cast<UINT_PTR>(obj)).c_str(),
+                DescribeHandle(reinterpret_cast<UINT_PTR>(previous)).c_str());
+  return previous;
+}
+
 BOOL WINAPI Hooked_BitBlt(HDC dest, int xDest, int yDest, int width, int height,
                           HDC src, int xSrc, int ySrc, DWORD rop) {
   DebugTraceLog(L"BitBlt(dest=%s, src=%s, size=%dx%d, rop=0x%08X)",
                 DescribeHandle(reinterpret_cast<UINT_PTR>(dest)).c_str(),
                 DescribeHandle(reinterpret_cast<UINT_PTR>(src)).c_str(), width,
                 height, rop);
-  return g_orig_BitBlt(dest, xDest, yDest, width, height, src, xSrc, ySrc, rop);
+  const BOOL result =
+      g_orig_BitBlt(dest, xDest, yDest, width, height, src, xSrc, ySrc, rop);
+  if (result && HasDiagnosticsBuffer()) {
+    bool captured = false;
+    if (ShouldSnapshotDiagnostics(dest)) {
+      captured = SnapshotDiagnosticsFromDc(dest, L"BitBlt dest");
+    }
+    if (!captured && ShouldSnapshotDiagnostics(src)) {
+      SnapshotDiagnosticsFromDc(src, L"BitBlt src");
+    }
+  }
+  return result;
 }
 
 BOOL WINAPI Hooked_StretchBlt(HDC dest, int xDest, int yDest, int widthDest,
@@ -435,8 +581,29 @@ BOOL WINAPI Hooked_StretchBlt(HDC dest, int xDest, int yDest, int widthDest,
                 DescribeHandle(reinterpret_cast<UINT_PTR>(dest)).c_str(),
                 DescribeHandle(reinterpret_cast<UINT_PTR>(src)).c_str(),
                 widthSrc, heightSrc, widthDest, heightDest, rop);
-  return g_orig_StretchBlt(dest, xDest, yDest, widthDest, heightDest, src, xSrc,
-                           ySrc, widthSrc, heightSrc, rop);
+  const BOOL result = g_orig_StretchBlt(dest, xDest, yDest, widthDest, heightDest,
+                                        src, xSrc, ySrc, widthSrc, heightSrc, rop);
+  if (result && HasDiagnosticsBuffer()) {
+    bool captured = false;
+    if (ShouldSnapshotDiagnostics(dest)) {
+      captured = SnapshotDiagnosticsFromDc(dest, L"StretchBlt dest");
+    }
+    if (!captured && ShouldSnapshotDiagnostics(src)) {
+      SnapshotDiagnosticsFromDc(src, L"StretchBlt src");
+    }
+  }
+  return result;
+}
+
+BOOL WINAPI Hooked_PatBlt(HDC dc, int x, int y, int width, int height, DWORD rop) {
+  DebugTraceLog(L"PatBlt(dc=%s, x=%d, y=%d, size=%dx%d, rop=0x%08X)",
+                DescribeHandle(reinterpret_cast<UINT_PTR>(dc)).c_str(), x, y,
+                width, height, rop);
+  const BOOL result = g_orig_PatBlt(dc, x, y, width, height, rop);
+  if (result && HasDiagnosticsBuffer() && ShouldSnapshotDiagnostics(dc)) {
+    SnapshotDiagnosticsFromDc(dc, L"PatBlt");
+  }
+  return result;
 }
 
 BOOL WINAPI Hooked_SwapBuffers(HDC dc) {
@@ -454,6 +621,16 @@ BOOL WINAPI Hooked_SetPixelFormat(HDC dc, int format,
   DebugTraceLog(L"SetPixelFormat(%s, %d)",
                 DescribeHandle(reinterpret_cast<UINT_PTR>(dc)).c_str(), format);
   return g_orig_SetPixelFormat(dc, format, pfd);
+}
+
+int WINAPI Hooked_DescribePixelFormat(HDC dc, int format, UINT bytes,
+                                      PIXELFORMATDESCRIPTOR *pfd) {
+  DebugTraceLog(L"DescribePixelFormat(dc=%s, format=%d, bytes=%u)",
+                DescribeHandle(reinterpret_cast<UINT_PTR>(dc)).c_str(), format,
+                bytes);
+  const int result = g_orig_DescribePixelFormat(dc, format, bytes, pfd);
+  DebugTraceLog(L"DescribePixelFormat -> %d", result);
+  return result;
 }
 
 HGLRC WINAPI Hooked_wglCreateContext(HDC dc) {
@@ -486,7 +663,7 @@ struct HookSpec {
   void *replacement;
 };
 
-const std::array<HookSpec, 20> kHookSpecs = {{{"user32.dll", "CreateWindowExW",
+const std::array<HookSpec, 25> kHookSpecs = {{{"user32.dll", "CreateWindowExW",
                                               reinterpret_cast<void *>(Hooked_CreateWindowExW)},
                                              {"user32.dll", "CreateWindowExA",
                                               reinterpret_cast<void *>(Hooked_CreateWindowExA)},
@@ -494,6 +671,8 @@ const std::array<HookSpec, 20> kHookSpecs = {{{"user32.dll", "CreateWindowExW",
                                               reinterpret_cast<void *>(Hooked_DestroyWindow)},
                                              {"user32.dll", "GetDC",
                                               reinterpret_cast<void *>(Hooked_GetDC)},
+                                             {"user32.dll", "GetDCEx",
+                                              reinterpret_cast<void *>(Hooked_GetDCEx)},
                                              {"user32.dll", "GetWindowDC",
                                               reinterpret_cast<void *>(Hooked_GetWindowDC)},
                                              {"user32.dll", "ReleaseDC",
@@ -506,28 +685,37 @@ const std::array<HookSpec, 20> kHookSpecs = {{{"user32.dll", "CreateWindowExW",
                                               reinterpret_cast<void *>(Hooked_CreateCompatibleDC)},
                                              {"gdi32.dll", "DeleteDC",
                                               reinterpret_cast<void *>(Hooked_DeleteDC)},
+                                             {"gdi32.dll", "CreateCompatibleBitmap",
+                                              reinterpret_cast<void *>(Hooked_CreateCompatibleBitmap)},
                                              {"gdi32.dll", "CreateDIBSection",
                                               reinterpret_cast<void *>(Hooked_CreateDIBSection)},
                                              {"gdi32.dll", "DeleteObject",
                                               reinterpret_cast<void *>(Hooked_DeleteObject)},
+                                             {"gdi32.dll", "SelectObject",
+                                              reinterpret_cast<void *>(Hooked_SelectObject)},
                                              {"gdi32.dll", "BitBlt",
                                               reinterpret_cast<void *>(Hooked_BitBlt)},
                                              {"gdi32.dll", "StretchBlt",
                                               reinterpret_cast<void *>(Hooked_StretchBlt)},
+                                             {"gdi32.dll", "PatBlt",
+                                              reinterpret_cast<void *>(Hooked_PatBlt)},
                                              {"gdi32.dll", "SwapBuffers",
                                               reinterpret_cast<void *>(Hooked_SwapBuffers)},
                                              {"gdi32.dll", "ChoosePixelFormat",
                                               reinterpret_cast<void *>(Hooked_ChoosePixelFormat)},
                                              {"gdi32.dll", "SetPixelFormat",
                                               reinterpret_cast<void *>(Hooked_SetPixelFormat)},
-                                             {"gdi32.dll", "wglCreateContext",
+                                             {"gdi32.dll", "DescribePixelFormat",
+                                              reinterpret_cast<void *>(Hooked_DescribePixelFormat)},
+                                             {"opengl32.dll", "wglCreateContext",
                                               reinterpret_cast<void *>(Hooked_wglCreateContext)},
-                                             {"gdi32.dll", "wglMakeCurrent",
+                                             {"opengl32.dll", "wglMakeCurrent",
                                               reinterpret_cast<void *>(Hooked_wglMakeCurrent)},
-                                             {"gdi32.dll", "wglDeleteContext",
+                                             {"opengl32.dll", "wglDeleteContext",
                                               reinterpret_cast<void *>(Hooked_wglDeleteContext)}}};
 
-bool ApplyHookToImport(HMODULE module, const HookSpec &spec) {
+bool ApplyHookToImport(HMODULE module, const HookSpec &spec,
+                       std::vector<std::wstring> *applied) {
   if (module == nullptr) {
     return false;
   }
@@ -590,6 +778,12 @@ bool ApplyHookToImport(HMODULE module, const HookSpec &spec) {
       *target = spec.replacement;
       VirtualProtect(target, sizeof(void *), old_protect, &old_protect);
       FlushInstructionCache(GetCurrentProcess(), target, sizeof(void *));
+      if (applied != nullptr) {
+        std::wstring entry = Widen(spec.dll_name);
+        entry += L"!";
+        entry += Widen(spec.function_name);
+        applied->push_back(std::move(entry));
+      }
       return true;
     }
   }
@@ -597,15 +791,15 @@ bool ApplyHookToImport(HMODULE module, const HookSpec &spec) {
   return false;
 }
 
-bool ApplyHooksToModule(HMODULE module) {
-  bool hooked_any = false;
+size_t ApplyHooksToModule(HMODULE module, std::vector<std::wstring> *applied) {
+  size_t hook_count = 0;
   for (const HookSpec &spec : kHookSpecs) {
-    const bool hooked = ApplyHookToImport(module, spec);
+    const bool hooked = ApplyHookToImport(module, spec, applied);
     if (hooked) {
-      hooked_any = true;
+      ++hook_count;
     }
   }
-  return hooked_any;
+  return hook_count;
 }
 
 void DestroyOffscreenSurfaceUnlocked() {
@@ -624,6 +818,109 @@ void DestroyOffscreenSurfaceUnlocked() {
   g_offscreen_surface.bits = nullptr;
   g_offscreen_surface.width = 0;
   g_offscreen_surface.height = 0;
+}
+
+void DestroyDiagnosticsBufferUnlocked() {
+  if (g_diagnostics_buffer.dc != nullptr) {
+    if (g_diagnostics_buffer.old_bitmap != nullptr) {
+      SelectObject(g_diagnostics_buffer.dc, g_diagnostics_buffer.old_bitmap);
+      g_diagnostics_buffer.old_bitmap = nullptr;
+    }
+    g_orig_DeleteDC(g_diagnostics_buffer.dc);
+    g_diagnostics_buffer.dc = nullptr;
+  }
+  if (g_diagnostics_buffer.bitmap != nullptr) {
+    g_orig_DeleteObject(g_diagnostics_buffer.bitmap);
+    g_diagnostics_buffer.bitmap = nullptr;
+  }
+  g_diagnostics_buffer.bits = nullptr;
+  g_diagnostics_buffer.width = 0;
+  g_diagnostics_buffer.height = 0;
+  g_diagnostics_buffer.generation = 0;
+}
+
+bool EnsureDiagnosticsBufferUnlocked(int width, int height) {
+  if (width <= 0 || height <= 0) {
+    return false;
+  }
+  if (HasDiagnosticsBufferUnlocked() && g_diagnostics_buffer.width == width &&
+      g_diagnostics_buffer.height == height) {
+    return true;
+  }
+
+  DestroyDiagnosticsBufferUnlocked();
+
+  HDC dc = g_orig_CreateCompatibleDC(nullptr);
+  if (dc == nullptr) {
+    return false;
+  }
+
+  BITMAPINFO bmi;
+  std::memset(&bmi, 0, sizeof(bmi));
+  bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+  bmi.bmiHeader.biWidth = width;
+  bmi.bmiHeader.biHeight = -height;
+  bmi.bmiHeader.biPlanes = 1;
+  bmi.bmiHeader.biBitCount = 32;
+  bmi.bmiHeader.biCompression = BI_RGB;
+
+  void *bits = nullptr;
+  HBITMAP bitmap =
+      g_orig_CreateDIBSection(dc, &bmi, DIB_RGB_COLORS, &bits, nullptr, 0);
+  if (bitmap == nullptr || bits == nullptr) {
+    g_orig_DeleteDC(dc);
+    return false;
+  }
+
+  HBITMAP old = static_cast<HBITMAP>(SelectObject(dc, bitmap));
+  g_diagnostics_buffer.dc = dc;
+  g_diagnostics_buffer.bitmap = bitmap;
+  g_diagnostics_buffer.old_bitmap = old;
+  g_diagnostics_buffer.bits = bits;
+  g_diagnostics_buffer.width = width;
+  g_diagnostics_buffer.height = height;
+  g_diagnostics_buffer.generation = 0;
+  return true;
+}
+
+bool ShouldSnapshotDiagnostics(HDC dc) {
+  if (dc == nullptr) {
+    return false;
+  }
+  if (IsOffscreenDc(dc)) {
+    return true;
+  }
+  HWND hwnd = WindowFromDC(dc);
+  if (hwnd != nullptr && IsTargetWindow(hwnd)) {
+    return true;
+  }
+  return false;
+}
+
+bool SnapshotDiagnosticsFromDc(HDC dc, const wchar_t *reason) {
+  if (dc == nullptr || reason == nullptr) {
+    return false;
+  }
+  uint64_t new_generation = 0;
+  {
+    std::lock_guard<std::mutex> lock(g_diagnostics_mutex);
+    if (!HasDiagnosticsBufferUnlocked()) {
+      return false;
+    }
+    const int width = g_diagnostics_buffer.width;
+    const int height = g_diagnostics_buffer.height;
+    if (width <= 0 || height <= 0) {
+      return false;
+    }
+    if (!g_orig_BitBlt(g_diagnostics_buffer.dc, 0, 0, width, height, dc, 0, 0,
+                       SRCCOPY)) {
+      return false;
+    }
+    new_generation = ++g_diagnostics_buffer.generation;
+  }
+  DebugTraceLog(L"Diagnostics buffer updated via %s (generation=%llu)", reason,
+                static_cast<unsigned long long>(new_generation));
+  return true;
 }
 
 } // namespace
@@ -691,20 +988,32 @@ void DebugTraceLog(const std::wstring &message) {
 bool DebugTraceInstallHooksForModule(HMODULE module,
                                      const std::wstring &module_name) {
   if (module == nullptr) {
+    DebugTraceLog(L"Skipping hook install for %s (module=null)",
+                  module_name.c_str());
     return false;
   }
   std::lock_guard<std::mutex> lock(g_hook_mutex);
   if (g_hooked_modules.find(module) != g_hooked_modules.end()) {
+    DebugTraceLog(L"Debug hooks already installed for %s (module=%s)",
+                  module_name.c_str(),
+                  FormatPointer(reinterpret_cast<UINT_PTR>(module)).c_str());
     return true;
   }
-  const bool hooked = ApplyHooksToModule(module);
-  if (hooked) {
+  std::vector<std::wstring> applied;
+  const size_t hook_count = ApplyHooksToModule(module, &applied);
+  if (hook_count > 0) {
     g_hooked_modules.insert(module);
-    DebugTraceLog(L"Installed debug hooks for module %s", module_name.c_str());
-  } else {
-    DebugTraceLog(L"No debug hooks applied to module %s", module_name.c_str());
+    DebugTraceLog(L"Installed %zu debug hooks for %s (module=%s)", hook_count,
+                  module_name.c_str(),
+                  FormatPointer(reinterpret_cast<UINT_PTR>(module)).c_str());
+    for (const std::wstring &entry : applied) {
+      DebugTraceLog(L"  hook: %s", entry.c_str());
+    }
+    return true;
   }
-  return hooked;
+  DebugTraceLog(L"No debug hooks applied to %s (module=%s)", module_name.c_str(),
+                FormatPointer(reinterpret_cast<UINT_PTR>(module)).c_str());
+  return false;
 }
 
 void DebugTraceRegisterTargetWindow(HWND hwnd) {
@@ -801,4 +1110,86 @@ bool DebugTraceCaptureOffscreenSurface(std::vector<uint8_t> &out_rgba) {
     dst[offset + 3] = src[offset + 3];
   }
   return true;
+}
+
+bool DebugTraceConfigureDiagnosticsBuffer(int width, int height) {
+  HDC dc = nullptr;
+  HBITMAP bitmap = nullptr;
+  void *bits = nullptr;
+  bool success = false;
+  {
+    std::lock_guard<std::mutex> lock(g_diagnostics_mutex);
+    if (width <= 0 || height <= 0) {
+      DestroyDiagnosticsBufferUnlocked();
+    } else {
+      success = EnsureDiagnosticsBufferUnlocked(width, height);
+      if (success) {
+        dc = g_diagnostics_buffer.dc;
+        bitmap = g_diagnostics_buffer.bitmap;
+        bits = g_diagnostics_buffer.bits;
+      }
+    }
+  }
+  if (width <= 0 || height <= 0) {
+    DebugTraceLog(L"Diagnostics buffer disabled (invalid size)");
+    return false;
+  }
+  if (!success) {
+    DebugTraceLog(L"ERROR: Failed to initialize diagnostics buffer %dx%d", width,
+                  height);
+    return false;
+  }
+  DebugTraceLog(L"Initialized diagnostics buffer %dx%d dc=%s bitmap=%s bits=%s",
+                width, height, FormatHdc(dc).c_str(),
+                FormatPointer(reinterpret_cast<UINT_PTR>(bitmap)).c_str(),
+                FormatPointer(reinterpret_cast<UINT_PTR>(bits)).c_str());
+  return true;
+}
+
+void DebugTraceResetDiagnosticsBuffer() {
+  bool had_buffer = false;
+  {
+    std::lock_guard<std::mutex> lock(g_diagnostics_mutex);
+    had_buffer = HasDiagnosticsBufferUnlocked();
+    DestroyDiagnosticsBufferUnlocked();
+  }
+  if (had_buffer) {
+    DebugTraceLog(L"Diagnostics buffer reset");
+  }
+}
+
+bool DebugTraceFetchLastFrame(uint64_t &in_out_generation,
+                              std::vector<uint8_t> &out_rgba) {
+  std::lock_guard<std::mutex> lock(g_diagnostics_mutex);
+  if (!HasDiagnosticsBufferUnlocked()) {
+    return false;
+  }
+  if (g_diagnostics_buffer.generation == 0 ||
+      g_diagnostics_buffer.generation == in_out_generation) {
+    return false;
+  }
+  const size_t pixel_count =
+      static_cast<size_t>(g_diagnostics_buffer.width) *
+      static_cast<size_t>(g_diagnostics_buffer.height);
+  if (pixel_count == 0) {
+    return false;
+  }
+  out_rgba.resize(pixel_count * 4);
+  const uint8_t *src =
+      static_cast<const uint8_t *>(g_diagnostics_buffer.bits);
+  uint8_t *dst = out_rgba.data();
+  const size_t bytes = pixel_count * 4;
+  for (size_t offset = 0; offset < bytes; offset += 4) {
+    dst[offset + 0] = src[offset + 2];
+    dst[offset + 1] = src[offset + 1];
+    dst[offset + 2] = src[offset + 0];
+    dst[offset + 3] = src[offset + 3];
+  }
+  in_out_generation = g_diagnostics_buffer.generation;
+  return true;
+}
+
+uint64_t DebugTracePeekDiagnosticsGeneration() {
+  std::lock_guard<std::mutex> lock(g_diagnostics_mutex);
+  return g_diagnostics_buffer.generation;
 }

--- a/tools/debug_trace.hpp
+++ b/tools/debug_trace.hpp
@@ -23,5 +23,11 @@ void DebugTraceResetOffscreenSurface();
 
 bool DebugTraceCaptureOffscreenSurface(std::vector<uint8_t> &out_rgba);
 
+bool DebugTraceConfigureDiagnosticsBuffer(int width, int height);
+void DebugTraceResetDiagnosticsBuffer();
+bool DebugTraceFetchLastFrame(uint64_t &in_out_generation,
+                              std::vector<uint8_t> &out_rgba);
+uint64_t DebugTracePeekDiagnosticsGeneration();
+
 bool DebugTraceIsActive();
 

--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -282,16 +282,21 @@ std::wstring FormatWindowsErrorMessage(DWORD error_code) {
 bool EnsureDirectoryExists(const std::wstring &path) {
   if (path.empty()) {
     std::wcerr << L"ERROR: Directory path is empty.\n";
+    DebugTraceLog(L"EnsureDirectoryExists failed: empty path");
     return false;
   }
+
+  DebugTraceLog(L"EnsureDirectoryExists request: %s", path.c_str());
 
   const DWORD attributes = GetFileAttributesW(path.c_str());
   if (attributes != INVALID_FILE_ATTRIBUTES) {
     if ((attributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+      DebugTraceLog(L"EnsureDirectoryExists OK (exists): %s", path.c_str());
       return true;
     }
     std::wcerr << L"ERROR: Path '" << path
                << L"' exists but is not a directory.\n";
+    DebugTraceLog(L"EnsureDirectoryExists failed: not a directory %s", path.c_str());
     return false;
   }
 
@@ -299,6 +304,8 @@ bool EnsureDirectoryExists(const std::wstring &path) {
   if (error != ERROR_FILE_NOT_FOUND && error != ERROR_PATH_NOT_FOUND) {
     std::wcerr << L"ERROR: GetFileAttributesW failed for '" << path
                << L"': " << FormatWindowsErrorMessage(error) << L"\n";
+    DebugTraceLog(L"EnsureDirectoryExists: GetFileAttributesW failed for %s error=%lu",
+                  path.c_str(), error);
     return false;
   }
 
@@ -311,16 +318,20 @@ bool EnsureDirectoryExists(const std::wstring &path) {
   }
 
   if (CreateDirectoryW(path.c_str(), nullptr)) {
+    DebugTraceLog(L"EnsureDirectoryExists created: %s", path.c_str());
     return true;
   }
 
   const DWORD create_error = GetLastError();
   if (create_error == ERROR_ALREADY_EXISTS) {
+    DebugTraceLog(L"EnsureDirectoryExists OK (already exists): %s", path.c_str());
     return true;
   }
 
   std::wcerr << L"ERROR: Failed to create directory '" << path
              << L"': " << FormatWindowsErrorMessage(create_error) << L"\n";
+  DebugTraceLog(L"EnsureDirectoryExists: CreateDirectory failed for %s error=%lu",
+                path.c_str(), create_error);
   return false;
 }
 
@@ -384,13 +395,16 @@ LRESULT CALLBACK AvsWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
       }
       switch (lParam) {
         case IPC_GETVERSION:
+          DebugTraceLog(L"AvsWindowProc: IPC_GETVERSION -> 0x2900");
           return 0x2900;
         case IPC_ISPLAYING:
+          DebugTraceLog(L"AvsWindowProc: IPC_ISPLAYING -> 1");
           return 1;
         case IPC_GETSKIN:
           if (wParam != 0) {
             std::strcpy(reinterpret_cast<char *>(wParam), "/tmp");
           }
+          DebugTraceLog(L"AvsWindowProc: IPC_GETSKIN -> %p", reinterpret_cast<void *>(wParam));
           return wParam;
         case IPC_GETINIFILE: {
           static char ini_path[1024] = "";
@@ -404,17 +418,23 @@ LRESULT CALLBACK AvsWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
               std::strcpy(dot_position, ".ini");
             }
           }
+          DebugTraceLog(L"AvsWindowProc: IPC_GETINIFILE -> %S", ini_path);
           return reinterpret_cast<LRESULT>(ini_path);
         }
-        case IPC_GET_EMBEDIF:
+        case IPC_GET_EMBEDIF: {
           if (g_parent_window != nullptr) {
             ShowWindow(g_parent_window, SW_SHOW);
           }
           if (wParam == 0) {
+            DebugTraceLog(L"AvsWindowProc: IPC_GET_EMBEDIF -> embed_window callback");
             return reinterpret_cast<LRESULT>(embed_window);
           }
-          return reinterpret_cast<LRESULT>(
-              embed_window(reinterpret_cast<embedWindowState *>(wParam)));
+          auto state = reinterpret_cast<embedWindowState *>(wParam);
+          HWND embed_target = embed_window(state);
+          DebugTraceLog(L"AvsWindowProc: IPC_GET_EMBEDIF state=%p -> %p", state,
+                        embed_target);
+          return reinterpret_cast<LRESULT>(embed_target);
+        }
         case IPC_SETVISWND:
           g_embedded_vis_window = reinterpret_cast<HWND>(wParam);
           DebugTraceLog(L"IPC_SETVISWND received, window=%p", g_embedded_vis_window);
@@ -430,6 +450,7 @@ LRESULT CALLBACK AvsWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
             container = g_parent_window;
           }
           ResizeEmbeddedWindow(container);
+          DebugTraceLog(L"AvsWindowProc: IPC_SETVISWND configured window=%p", container);
           return 0;
       }
       break;
@@ -584,6 +605,8 @@ struct Options {
   std::wstring avi_out;
   int png_step = 1;
   HashMode hash_mode = HashMode::kPixels;
+  std::wstring trace_log = L"avs_debug_trace.log";
+  bool diagnostics_fallback_enabled = true;
 };
 
 void PrintUsage(const std::wstring &command_name) {
@@ -592,7 +615,7 @@ void PrintUsage(const std::wstring &command_name) {
     const wchar_t *description;
   };
 
-  const std::array<OptionHelp, 15> kOptions = {
+  const std::array<OptionHelp, 17> kOptions = {
       OptionHelp{L"--vis-dll <path>", L"Path to vis DLL (required)"},
       OptionHelp{L"--runtime-dir <dir>",
                  L"Runtime directory (default: directory of vis DLL)"},
@@ -611,6 +634,10 @@ void PrintUsage(const std::wstring &command_name) {
                  L"Interval between PNG dumps (default: 1)"},
       OptionHelp{L"--hash-mode <mode>",
                  L"Hashing mode: pixels|rolling (default: pixels)"},
+      OptionHelp{L"--trace-log <filename>",
+                 L"Diagnostics log filename (default: avs_debug_trace.log)"},
+      OptionHelp{L"--disable-diagnostics-fallback",
+                 L"Disable diagnostics buffer capture fallback"},
       OptionHelp{L"--help, -h", L"Show this help message"},
   };
 
@@ -683,6 +710,11 @@ void PrintSummary(const Options &options) {
   std::wcout << L"  PNG step:              " << options.png_step << L"\n";
   std::wcout << L"  Hash mode:             "
              << (options.hash_mode == HashMode::kPixels ? L"pixels" : L"rolling")
+             << L"\n";
+  std::wcout << L"  Trace log filename:    " << options.trace_log << L"\n";
+  std::wcout << L"  Diagnostics fallback:  "
+             << (options.diagnostics_fallback_enabled ? L"enabled"
+                                                      : L"disabled")
              << L"\n";
 }
 
@@ -762,6 +794,10 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
           std::wcerr << L"ERROR: Option '--hash-mode' expects 'pixels' or 'rolling'.\n";
           return 1;
         }
+      } else if (current == L"--trace-log") {
+        options.trace_log = require_value(current);
+      } else if (current == L"--disable-diagnostics-fallback") {
+        options.diagnostics_fallback_enabled = false;
       } else {
         std::wcerr << L"ERROR: Unknown option '" << current << L"'.\n";
         return 1;
@@ -1039,12 +1075,16 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     return 1;
   }
 
-  const std::filesystem::path trace_log_path =
-      logs_dir_path / L"avs_debug_trace.log";
+  std::filesystem::path trace_log_path(options.trace_log);
+  if (!trace_log_path.is_absolute()) {
+    trace_log_path = logs_dir_path / trace_log_path;
+  }
+  trace_log_path = trace_log_path.lexically_normal();
   struct DebugTraceGuard {
     bool active = false;
     ~DebugTraceGuard() {
       if (active) {
+        DebugTraceResetDiagnosticsBuffer();
         DebugTraceResetOffscreenSurface();
         DebugTraceShutdown();
       }
@@ -1056,6 +1096,8 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     return 1;
   }
   trace_guard.active = true;
+  DebugTraceInstallHooksForModule(GetModuleHandleW(nullptr),
+                                  L"visdriver host process");
   DebugTraceLog(L"Debug trace logging to %s", trace_log_path.c_str());
   DebugTraceLog(L"Render options: %dx%d @ %d FPS for %d frames", options.width,
                 options.height, options.fps, options.frames);
@@ -1149,6 +1191,13 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
   }
   if (!DebugTraceConfigureOffscreenSurface(options.width, options.height)) {
     DebugTraceLog(L"WARNING: Offscreen surface setup failed");
+  }
+  if (options.diagnostics_fallback_enabled) {
+    if (!DebugTraceConfigureDiagnosticsBuffer(options.width, options.height)) {
+      DebugTraceLog(L"WARNING: Diagnostics buffer setup failed");
+    }
+  } else {
+    DebugTraceLog(L"Diagnostics fallback disabled by option");
   }
 
   host.mod->delayMs = (options.fps > 0) ? (1000 / options.fps) : 0;
@@ -1284,6 +1333,7 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     }
   }
   Sha256 rolling_hash;
+  uint64_t diagnostics_generation = 0;
 
   for (int frame = 0; frame < options.frames; ++frame) {
     if (!PumpPendingWindowMessages()) {
@@ -1330,29 +1380,57 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
 
     std::wcout << L"Frame " << (frame + 1) << L"/" << options.frames
                << L": start=" << start_sample << L", hop=" << hop << L"\n";
+    DebugTraceLog(L"Frame %d: begin", frame);
     DebugTraceLog(L"Frame %d: waveform start=%d hop=%d", frame, start_sample, hop);
 
     const int render_result = host.mod->Render(host.mod);
     DebugTraceLog(L"Frame %d: Render returned %d", frame, render_result);
     if (render_result != 0) {
       DebugTraceLog(L"Frame %d: Render aborted", frame);
+      DebugTraceLog(L"Frame %d: end (render aborted)", frame);
       break;
     }
 
-    bool captured = DebugTraceCaptureOffscreenSurface(frame_rgba);
-    if (captured) {
-      DebugTraceLog(L"Frame %d: captured from offscreen surface", frame);
-    } else {
-      DebugTraceLog(L"Frame %d: offscreen capture unavailable, falling back to window DC",
-                    frame);
+    bool captured = false;
+    if (options.diagnostics_fallback_enabled) {
+      const uint64_t previous_generation = diagnostics_generation;
+      if (DebugTraceFetchLastFrame(diagnostics_generation, frame_rgba)) {
+        DebugTraceLog(L"Frame %d: captured from diagnostics buffer (generation=%llu)",
+                      frame, static_cast<unsigned long long>(diagnostics_generation));
+        captured = true;
+      } else {
+        const uint64_t peek_generation = DebugTracePeekDiagnosticsGeneration();
+        if (peek_generation == 0) {
+          DebugTraceLog(L"Frame %d: diagnostics buffer empty", frame);
+        } else if (peek_generation == previous_generation) {
+          DebugTraceLog(L"Frame %d: diagnostics buffer unchanged (generation=%llu)",
+                        frame, static_cast<unsigned long long>(peek_generation));
+        } else {
+          DebugTraceLog(L"Frame %d: diagnostics buffer stale (prev=%llu current=%llu)",
+                        frame, static_cast<unsigned long long>(previous_generation),
+                        static_cast<unsigned long long>(peek_generation));
+        }
+      }
+    }
+    if (!captured) {
+      captured = DebugTraceCaptureOffscreenSurface(frame_rgba);
+      if (captured) {
+        DebugTraceLog(L"Frame %d: captured from offscreen surface", frame);
+      } else {
+        DebugTraceLog(L"Frame %d: offscreen capture unavailable", frame);
+      }
+    }
+    if (!captured) {
+      DebugTraceLog(L"Frame %d: attempting window capture fallback", frame);
       if (!capture_child_to_rgba(host.child, options.width, options.height,
                                  frame_rgba)) {
         std::wcerr << L"ERROR: Failed to capture frame " << frame << L".\n";
         DebugTraceLog(L"Frame %d: window capture failed", frame);
         capture_failed = true;
+        DebugTraceLog(L"Frame %d: end (capture failure)", frame);
         break;
       }
-
+      DebugTraceLog(L"Frame %d: captured from window DC", frame);
     }
 
     if (avi_enabled && !avi_failed) {
@@ -1361,6 +1439,7 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
                              options.height, effective_fps)) {
           avi_failed = true;
           DebugTraceLog(L"Frame %d: failed to open AVI output", frame);
+          DebugTraceLog(L"Frame %d: end (AVI open failure)", frame);
           break;
         }
         avi_opened = true;
@@ -1369,6 +1448,7 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
       if (!avi_writer.WriteFrame(frame_rgba.data(), frame_rgba.size())) {
         avi_failed = true;
         DebugTraceLog(L"Frame %d: failed to append frame to AVI", frame);
+        DebugTraceLog(L"Frame %d: end (AVI write failure)", frame);
         break;
       }
     }
@@ -1381,6 +1461,7 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
                  << L".\n";
       DebugTraceLog(L"Frame %d: failed to append per-frame hash", frame);
       hash_failed = true;
+      DebugTraceLog(L"Frame %d: end (hash failure)", frame);
       break;
     }
     rolling_hash.Update(frame_rgba);
@@ -1393,6 +1474,7 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
         capture_failed = true;
         DebugTraceLog(L"Frame %d: failed to write PNG %s", frame,
                       png_path.wstring().c_str());
+        DebugTraceLog(L"Frame %d: end (PNG failure)", frame);
         break;
       }
       png_outputs.push_back(png_path);
@@ -1400,6 +1482,8 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
       DebugTraceLog(L"Frame %d: wrote PNG %s", frame,
                     png_path.wstring().c_str());
     }
+
+    DebugTraceLog(L"Frame %d: end", frame);
   }
 
   if (avi_writer.IsOpen()) {

--- a/tools/vis_host.cpp
+++ b/tools/vis_host.cpp
@@ -2,6 +2,8 @@
 
 #include <iostream>
 
+#include "debug_trace.hpp"
+
 namespace {
 
 std::wstring FormatWindowsErrorMessage(DWORD error_code) {
@@ -35,18 +37,24 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   VisHost host;
   host.parent = parent;
 
+  DebugTraceLog(L"load_vis: attempting to load %s", dll_path.c_str());
   host.dll = LoadLibraryW(dll_path.c_str());
   if (host.dll == nullptr) {
     const DWORD error = GetLastError();
     std::wcerr << L"ERROR: Failed to load vis DLL '" << dll_path
                << L"': " << FormatWindowsErrorMessage(error) << L"\n";
+    DebugTraceLog(L"load_vis: LoadLibraryW failed for %s error=%lu", dll_path.c_str(),
+                  error);
     return host;
   }
+
+  DebugTraceLog(L"load_vis: loaded %s module=%p", dll_path.c_str(), host.dll);
 
   FARPROC proc = GetProcAddress(host.dll, "winampVisGetHeader");
   if (proc == nullptr) {
     std::wcerr << L"ERROR: Symbol 'winampVisGetHeader' not found in '" << dll_path
                << L"'.\n";
+    DebugTraceLog(L"load_vis: winampVisGetHeader missing in %s", dll_path.c_str());
     FreeLibrary(host.dll);
     host.dll = nullptr;
     return host;
@@ -57,6 +65,8 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   if (header == nullptr) {
     std::wcerr << L"ERROR: winampVisGetHeader returned null for '" << dll_path
                << L"'.\n";
+    DebugTraceLog(L"load_vis: winampVisGetHeader returned null for %s",
+                  dll_path.c_str());
     FreeLibrary(host.dll);
     host.dll = nullptr;
     return host;
@@ -65,6 +75,7 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   if (header->getModule == nullptr) {
     std::wcerr << L"ERROR: winampVisHeader::getModule is null in '" << dll_path
                << L"'.\n";
+    DebugTraceLog(L"load_vis: getModule is null for %s", dll_path.c_str());
     FreeLibrary(host.dll);
     host.dll = nullptr;
     return host;
@@ -74,6 +85,7 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   if (module == nullptr) {
     std::wcerr << L"ERROR: Failed to fetch first vis module from '" << dll_path
                << L"'.\n";
+    DebugTraceLog(L"load_vis: getModule returned null for %s", dll_path.c_str());
     FreeLibrary(host.dll);
     host.dll = nullptr;
     return host;
@@ -82,10 +94,15 @@ VisHost load_vis(const std::wstring &dll_path, HWND parent) {
   host.hdr = header;
   host.mod = module;
 
+  DebugTraceLog(L"load_vis: module acquired header=%p module=%p", host.hdr,
+                host.mod);
+
   return host;
 }
 
 void unload_vis(VisHost &host) {
+  DebugTraceLog(L"unload_vis: module=%p child=%p parent=%p", host.dll, host.child,
+                host.parent);
   if (host.child != nullptr) {
     DestroyWindow(host.child);
     host.child = nullptr;
@@ -98,6 +115,7 @@ void unload_vis(VisHost &host) {
   host.mod = nullptr;
   if (host.dll != nullptr) {
     FreeLibrary(host.dll);
+    DebugTraceLog(L"unload_vis: freed module handle=%p", host.dll);
     host.dll = nullptr;
   }
 }
@@ -105,10 +123,13 @@ void unload_vis(VisHost &host) {
 bool begin_vis(VisHost &host, int width, int height) {
   if (host.mod == nullptr) {
     std::wcerr << L"ERROR: Visualization module handle is null.\n";
+    DebugTraceLog(L"begin_vis: module handle null");
     return false;
   }
 
   HWND const target_window = (host.child != nullptr) ? host.child : host.parent;
+  DebugTraceLog(L"begin_vis: target=%p width=%d height=%d", target_window, width,
+                height);
   host.mod->hwndParent = target_window;
   host.mod->hDllInstance = host.dll;
   host.mod->sRate = 44100;
@@ -124,6 +145,7 @@ bool begin_vis(VisHost &host, int width, int height) {
 
   if (host.mod->Init == nullptr) {
     std::wcerr << L"ERROR: Visualization module is missing Init().\n";
+    DebugTraceLog(L"begin_vis: Init missing for module=%p", host.mod);
     return false;
   }
 
@@ -131,18 +153,22 @@ bool begin_vis(VisHost &host, int width, int height) {
   if (init_result != 0) {
     std::wcerr << L"ERROR: Visualization module Init() returned "
                << init_result << L".\n";
+    DebugTraceLog(L"begin_vis: Init returned %d", init_result);
     return false;
   }
 
+  DebugTraceLog(L"begin_vis: Init success");
   return true;
 }
 
 void end_vis(VisHost &host) {
   if (host.mod != nullptr && host.mod->Quit != nullptr) {
+    DebugTraceLog(L"end_vis: calling Quit on module=%p", host.mod);
     host.mod->Quit(host.mod);
   }
 
   if (host.child != nullptr) {
+    DebugTraceLog(L"end_vis: destroying child window=%p", host.child);
     DestroyWindow(host.child);
     host.child = nullptr;
   }


### PR DESCRIPTION
## Summary
- expand DebugTrace GDI hook coverage and add diagnostics buffer snapshots with generation-tracked FetchLastFrame support
- prefer the diagnostics buffer during generate_verification_data captures, add CLI flags, and enrich logging across tools
- improve module lifecycle tracing and link against opengl32 to satisfy new diagnostics references

## Testing
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68e0b09eb7ec832c8bc67e6363ea1e28