### PR TITLE
Guard host hook installation under Wine

### DIFF
--- a/tools/generate_verification_data.cpp
+++ b/tools/generate_verification_data.cpp
@@ -185,6 +185,15 @@ bool WaitForEmbeddedVisWindow(const VisHost &host, DWORD timeout_ms) {
   return found;
 }
 
+bool IsRunningUnderWine() {
+  HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+  if (ntdll == nullptr) {
+    return false;
+  }
+  FARPROC wine_get_version = GetProcAddress(ntdll, "wine_get_version");
+  return wine_get_version != nullptr;
+}
+
 struct HandleCloser {
   void operator()(HANDLE handle) const {
     if (handle != nullptr && handle != INVALID_HANDLE_VALUE) {
@@ -1096,8 +1105,12 @@ extern "C" int cmd_generate_verification_data(int argc, wchar_t **argv) {
     return 1;
   }
   trace_guard.active = true;
-  DebugTraceInstallHooksForModule(GetModuleHandleW(nullptr),
-                                  L"visdriver host process");
+  if (!IsRunningUnderWine()) {
+    DebugTraceInstallHooksForModule(GetModuleHandleW(nullptr),
+                                    L"visdriver host process");
+  } else {
+    DebugTraceLog(L"Skipping host process debug hooks under Wine");
+  }
   DebugTraceLog(L"Debug trace logging to %s", trace_log_path.c_str());
   DebugTraceLog(L"Render options: %dx%d @ %d FPS for %d frames", options.width,
                 options.height, options.fps, options.frames);


### PR DESCRIPTION
## Summary
- add a helper that detects whether the process is running under Wine
- skip installing host-process debug hooks when Wine is detected and log the decision

## Testing
- not run (requires mingw-w64 toolchain and Wine runtime)

------
https://chatgpt.com/codex/tasks/task_e_68e0fa3d2bb0832cabdf797b16798106