### PR TITLE
Document 32-bit Wine requirements for Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,16 @@
 
 * Build with **CMake** and **MinGW**.
 
-* In Ubuntu environments install the `build-essential`, `cmake`, `ccache`, `mingw-w64`, and `wine32` packages same as `.ci/ubuntu-packages.txt` (e.g. `sudo apt-get install -y build-essential cmake ccache mingw-w64 wine`).
+* In Ubuntu environments enable multi-arch and install the `build-essential`, `cmake`, `ccache`, `mingw-w64`, `wine`, `wine64`, and `wine32:i386` packages, matching `.ci/ubuntu-packages.txt`.
   Install them with:
 
 ```bash
+sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install --yes build-essential cmake ccache mingw-w64 wine wine32
+sudo apt-get install --yes build-essential cmake ccache mingw-w64 wine wine64 wine32:i386
 ```
+  A Linux host must support 32-bit userspace binaries (`CONFIG_IA32_EMULATION` on x86\_64). If `/usr/lib/i386-linux-gnu/glib-2.0/glib-compile-schemas --version`
+  exits with `Exec format error`, the kernel cannot execute 32-bit ELF binaries and a 32-bit Wine prefix will not start.
 * Dependencies are vendored header-only or tiny C libs (no big external deps).
 
 ### Build 
@@ -34,7 +37,8 @@ cmake
 ccache
 mingw-w64
 wine
-wine32
+wine64
+wine32:i386
 ```
 
 copy the necessary dlls into the directory with the executable 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,28 @@ its page will list artifacts for download near the bottom.
 
 On a fresh Ubuntu 24.04 environment the MinGW toolchain and Wine runtime are
 not available by default. Install the packages that mirror our CI environment
-first
+first. Enabling the `i386` architecture is required before the 32-bit Wine
+packages (`wine32:i386`) are visible to `apt`:
 
 
 ```console
+sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install -y build-essential cmake ccache mingw-w64 wine wine32
+sudo apt-get install -y build-essential cmake ccache mingw-w64 wine wine64 wine32:i386
+```
+
+If the helper binary `/usr/lib/i386-linux-gnu/glib-2.0/glib-compile-schemas`
+exits with `Exec format error`, the host kernel cannot run 32-bit ELF binaries.
+Wine cannot create a 32-bit prefix in that configuration; use a machine with
+`CONFIG_IA32_EMULATION` enabled or a VM/container that provides 32-bit support.
+
+Before building or running visdriver, create a dedicated 32-bit Wine prefix:
+
+```console
+export WINEARCH=win32
+export WINEPREFIX="$HOME/.wine32"
+wineboot -i
+winecfg    # optional, requires an X11 server
 ```
 
 With the dependencies in place, configure and build using the MinGW toolchain
@@ -159,28 +175,30 @@ Options:
 
 In this example, visdriver.exe was placed in the Program Files (x86)\Winamp installation directory.
 Take note of the effect of the --runtime-dir option on the other options search paths, it's not possible
-to omit this value as it is automatically set to the path where `vis_avs.dat` is located. It's just 
+to omit this value as it is automatically set to the path where `vis_avs.dat` is located. It's just
 a small annoyance.
 
-```
-export WINEPREFIX="$HOME/.wine32"
-export WINEARCH=win32
-wineboot -i            
-winecfg
+Before running from the MinGW build tree, copy the support DLLs and test data that
+the Codex harness provides:
+
+```console
+cp for_codex/dll/* build/
+cp -R for_codex/tests build/
+cd build
 ```
 
 ```
-# then run your app with that prefix:
-WINEPREFIX="$HOME/.wine32 .\visdriver.exe generate-verification-data`
- --runtime-dir .\Plugins\`
- --vis-avs-dat .\vis_avs.dat`
- --vis-dll .\vis_avs.dll`
- --out-dll .\out_wave.dll`
- --preset .\tests\data\phase1\color_mod.avs`
- --wav .\Plugins\tests\data\electronic.wav`
- --out-dir .\tests\out\`
- --avi-out test.avi
- --width 1000 --height 600
+# then run your app with that prefix from the MinGW build directory:
+WINEPREFIX="$HOME/.wine32" wine visdriver.exe generate-verification-data \
+  --runtime-dir ./ \
+  --vis-avs-dat ./vis_avs.dat \
+  --vis-dll ./vis_avs.dll \
+  --out-dll ./out_wave.dll \
+  --preset ./tests/data/phase1/color_mod.avs \
+  --wav ./tests/data/test.wav \
+  --out-dir ./tests/out/ \
+  --avi-out test.avi \
+  --width 1000 --height 600
 ```
 
 ### CLI Output


### PR DESCRIPTION
## Summary
- document enabling i386 multi-arch and installing wine32:i386/wine64 in AGENTS instructions
- expand the README with explicit 32-bit Wine prefix setup steps and clarify copying Codex DLL/test data before running
- fix the generate-verification-data example command so it uses the staged assets and consistent quoting

## Testing
- `cmake -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build`
- `make -C build -j$(nproc) VERBOSE=1`


------
https://chatgpt.com/codex/tasks/task_e_68e0fb9227e0832cbb29c9464871eede