### PR TITLE
Document 32-bit Wine setup requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,13 @@
 
 * Build with **CMake** and **MinGW**.
 
-* In Ubuntu environments install the `build-essential`, `cmake`, `ccache`, `mingw-w64`, and `wine32` packages same as `.ci/ubuntu-packages.txt` (e.g. `sudo apt-get install -y build-essential cmake ccache mingw-w64 wine`).
+* In Ubuntu environments install the `build-essential`, `cmake`, `ccache`, `mingw-w64`, and Wine packages same as `.ci/ubuntu-packages.txt`. Enable the 32-bit (`i386`) architecture before installing so that `wine32` packages can be resolved.
   Install them with:
 
 ```bash
+sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install --yes build-essential cmake ccache mingw-w64 wine wine32
+sudo apt-get install --yes build-essential cmake ccache mingw-w64 wine wine32:i386
 ```
 * Dependencies are vendored header-only or tiny C libs (no big external deps).
 
@@ -68,14 +69,17 @@ configure 32 bit wineprefix to run your app
 ```
 export WINEPREFIX="$HOME/.wine32"
 export WINEARCH=win32
-wineboot -i            
+wine --version
+wineboot -i
 winecfg
 ```
-then ensure the prefix is set to the environment variable before running 
+then ensure the prefix is set to the environment variable before running
 ```
 cd build
 WINEPREFIX="$HOME/.wine32" wine visdriver.exe generate-verification-data --vis-dll ./vis_avs.dll  --vis-avs-dat ./vis_avs.dat --runtime-dir ./  --wav ./tests/data/test.wav --preset  ./tests/data/phase1/simple.avs --out-dir ./tests/golden/phase1/simple
 ```
+
+If any Wine command reports `Exec format error`, run `uname -a` and verify that the host kernel supports 32-bit execution (look for `CONFIG_IA32_EMULATION=y`). Wine cannot launch 32-bit Windows binaries without that kernel feature; switch to an environment with 32-bit support before retrying.
 
 
   

--- a/README.md
+++ b/README.md
@@ -64,12 +64,14 @@ its page will list artifacts for download near the bottom.
 
 On a fresh Ubuntu 24.04 environment the MinGW toolchain and Wine runtime are
 not available by default. Install the packages that mirror our CI environment
-first
+first. Because we rely on 32-bit Wine, make sure the `i386` architecture is
+enabled prior to installation:
 
 
 ```console
+sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install -y build-essential cmake ccache mingw-w64 wine wine32
+sudo apt-get install -y build-essential cmake ccache mingw-w64 wine wine32:i386
 ```
 
 With the dependencies in place, configure and build using the MinGW toolchain
@@ -92,9 +94,29 @@ make -C build -j$(nproc) VERBOSE=1
 
 # How to Run
 
+Before running the executable make sure your Wine installation can launch
+32-bit binaries:
+
+```console
+WINEPREFIX="$HOME/.wine32" WINEARCH=win32 wine --version
+```
+
+If this command fails with `Exec format error` your kernel is missing
+`CONFIG_IA32_EMULATION` support; rerun these steps on a host that can execute
+32-bit ELF binaries.
+
+With a working Wine install, create a fresh 32-bit prefix and configure it once:
+
+```console
+export WINEPREFIX="$HOME/.wine32"
+export WINEARCH=win32
+wineboot -i
+winecfg  # optional tweaks
+```
+
 Let **visdriver** tell you what it needs:
 ```console
-# WINEDEBUG=-all wine ./build/visdriver.exe --help
+WINEDEBUG=-all WINEPREFIX="$HOME/.wine32" wine ./build/visdriver.exe --help
 Usage: visdriver [OPTIONS] --in PATH/IN.dll --out PATH/OUT.dll --vis PATH/VIS.dll [--] [AUDIO_FILE ..]
    or: visdriver --help
    or: visdriver --version
@@ -119,14 +141,12 @@ If you end up with errors about missing DLLs, copying these files in place
 should help.  E.g. for MinGW DLLs on Ubuntu 24.04 it would be:
 
 ```console
-# cp -v \
+cp -v \
     /usr/i686-w64-mingw32/lib/libwinpthread-1.dll \
     /usr/lib/gcc/i686-w64-mingw32/*-posix/libgcc_s_dw2-1.dll \
     /usr/lib/gcc/i686-w64-mingw32/*-posix/libstdc++-6.dll \
-    .
+    ./build/
 ```
-
-The locations of these files vary among GNU/Linux distros.
 
 
 ## `visdriver.exe generate-verification-data` operation
@@ -157,10 +177,9 @@ Options:
 
 ### Example Usage
 
-In this example, visdriver.exe was placed in the Program Files (x86)\Winamp installation directory.
-Take note of the effect of the --runtime-dir option on the other options search paths, it's not possible
-to omit this value as it is automatically set to the path where `vis_avs.dat` is located. It's just 
-a small annoyance.
+In this example we launch the executable from the directory containing the DLLs and presets.
+Take note of the effect of the `--runtime-dir` option on the other option search paths; it defaults to
+the directory that holds `vis_avs.dat` so you will rarely want to omit it.
 
 ```
 export WINEPREFIX="$HOME/.wine32"
@@ -171,16 +190,16 @@ winecfg
 
 ```
 # then run your app with that prefix:
-WINEPREFIX="$HOME/.wine32 .\visdriver.exe generate-verification-data`
- --runtime-dir .\Plugins\`
- --vis-avs-dat .\vis_avs.dat`
- --vis-dll .\vis_avs.dll`
- --out-dll .\out_wave.dll`
- --preset .\tests\data\phase1\color_mod.avs`
- --wav .\Plugins\tests\data\electronic.wav`
- --out-dir .\tests\out\`
- --avi-out test.avi
- --width 1000 --height 600
+WINEPREFIX="$HOME/.wine32" wine ./visdriver.exe generate-verification-data \
+  --runtime-dir . \
+  --vis-avs-dat ./vis_avs.dat \
+  --vis-dll ./vis_avs.dll \
+  --out-dll ./out_wave.dll \
+  --preset ./tests/data/phase1/color_mod.avs \
+  --wav ./tests/data/electronic.wav \
+  --out-dir ./tests/out \
+  --avi-out test.avi \
+  --width 1000 --height 600
 ```
 
 ### CLI Output


### PR DESCRIPTION
## Summary
- document enabling the i386 architecture before installing the Wine toolchain dependencies on Linux
- expand the run instructions to verify Wine’s 32-bit support and explain how to initialise the prefix
- fix the `generate-verification-data` example command to use shell-friendly syntax and updated asset paths

## Testing
- cmake -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build
- make -C build -j$(nproc) VERBOSE=1
- WINEPREFIX="$HOME/.wine32" wine visdriver.exe --help *(fails: Exec format error because host kernel lacks 32-bit support)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fb9227e0832cbb29c9464871eede