### PR TITLE
Document 32-bit Wine setup requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,21 @@
 
 * Build with **CMake** and **MinGW**.
 
-* In Ubuntu environments install the `build-essential`, `cmake`, `ccache`, `mingw-w64`, and `wine32` packages same as `.ci/ubuntu-packages.txt` (e.g. `sudo apt-get install -y build-essential cmake ccache mingw-w64 wine`).
-  Install them with:
+* In Ubuntu environments install the `build-essential`, `cmake`, `ccache`,
+  `mingw-w64`, and Wine packages same as `.ci/ubuntu-packages.txt`. Enable
+  32-bit packages before installing Wine:
 
 ```bash
+sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install --yes build-essential cmake ccache mingw-w64 wine wine32
+sudo apt-get install --yes \
+    build-essential cmake ccache mingw-w64 \
+    wine wine64 wine32:i386 winbind xvfb
 ```
+
+* If `wine --version` exits with `Exec format error`, the host kernel does not
+  have `CONFIG_IA32_EMULATION` enabled. Use a kernel/VM that supports 32-bit
+  binaries; Wine cannot run otherwise.
 * Dependencies are vendored header-only or tiny C libs (no big external deps).
 
 ### Build 
@@ -34,7 +42,10 @@ cmake
 ccache
 mingw-w64
 wine
-wine32
+wine64
+wine32:i386
+winbind
+xvfb
 ```
 
 copy the necessary dlls into the directory with the executable 
@@ -68,13 +79,13 @@ configure 32 bit wineprefix to run your app
 ```
 export WINEPREFIX="$HOME/.wine32"
 export WINEARCH=win32
-wineboot -i            
-winecfg
+wineboot --init
+# optional: xvfb-run winecfg
 ```
-then ensure the prefix is set to the environment variable before running 
+then ensure the prefix is set to the environment variable before running
 ```
 cd build
-WINEPREFIX="$HOME/.wine32" wine visdriver.exe generate-verification-data --vis-dll ./vis_avs.dll  --vis-avs-dat ./vis_avs.dat --runtime-dir ./  --wav ./tests/data/test.wav --preset  ./tests/data/phase1/simple.avs --out-dir ./tests/golden/phase1/simple
+WINEPREFIX="$HOME/.wine32" wine visdriver.exe generate-verification-data --vis-dll ./vis_avs.dll --vis-avs-dat ./vis_avs.dat --runtime-dir ./ --wav ./tests/data/test.wav --preset ./tests/data/phase1/simple.avs --out-dir ./tests/golden/phase1/simple
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -64,13 +64,22 @@ its page will list artifacts for download near the bottom.
 
 On a fresh Ubuntu 24.04 environment the MinGW toolchain and Wine runtime are
 not available by default. Install the packages that mirror our CI environment
-first
-
+first. Make sure 32-bit packages are enabled before installing Wine:
 
 ```console
+sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install -y build-essential cmake ccache mingw-w64 wine wine32
+sudo apt-get install -y \
+    build-essential cmake ccache mingw-w64 \
+    wine wine64 wine32:i386 winbind xvfb
 ```
+
+> **Heads-up:** Wine requires Linux kernels with the `CONFIG_IA32_EMULATION`
+> option enabled to execute 32-bit binaries. If `wine --version` exits with
+> `Exec format error`, check `/proc/sys/abi/ia32_emulation`. When that file is
+> missing or contains `0`, the host kernel cannot execute 32-bit code and the
+> Wine runtime will not start. In that case use a different kernel or a virtual
+> machine that provides 32-bit compatibility.
 
 With the dependencies in place, configure and build using the MinGW toolchain
 file provided by this repository.
@@ -92,9 +101,22 @@ make -C build -j$(nproc) VERBOSE=1
 
 # How to Run
 
-Let **visdriver** tell you what it needs:
+After the build finishes copy the support DLLs into the build directory and
+initialise a 32-bit Wine prefix:
 ```console
-# WINEDEBUG=-all wine ./build/visdriver.exe --help
+cp for_codex/dll/* build/
+cp -R for_codex/tests build/
+export WINEPREFIX="$HOME/.wine32"
+export WINEARCH=win32
+wineboot --init
+```
+
+If you are on a headless machine, run `winecfg` via `xvfb-run winecfg` or skip
+it entirely; it is only required when you want to tweak Wine settings.
+
+Now let **visdriver** tell you what it needs:
+```console
+WINEPREFIX="$HOME/.wine32" WINEDEBUG=-all wine ./build/visdriver.exe --help
 Usage: visdriver [OPTIONS] --in PATH/IN.dll --out PATH/OUT.dll --vis PATH/VIS.dll [--] [AUDIO_FILE ..]
    or: visdriver --help
    or: visdriver --version
@@ -131,8 +153,9 @@ The locations of these files vary among GNU/Linux distros.
 
 ## `visdriver.exe generate-verification-data` operation
 
-visdriver.ex has beem extended to provide the `generate-verification-data` operation. This has been implemented specifically to support generation of test data
-to be used in the development of new versions/ports of AVS. 
+`visdriver.exe` has been extended to provide the `generate-verification-data`
+operation. This has been implemented specifically to support generation of test
+data to be used in the development of new versions/ports of AVS.
 
 ### CLI-options
 ```
@@ -157,30 +180,30 @@ Options:
 
 ### Example Usage
 
-In this example, visdriver.exe was placed in the Program Files (x86)\Winamp installation directory.
-Take note of the effect of the --runtime-dir option on the other options search paths, it's not possible
-to omit this value as it is automatically set to the path where `vis_avs.dat` is located. It's just 
-a small annoyance.
+In this example, `visdriver.exe` was placed in the `Program Files (x86)\Winamp`
+installation directory. Take note of the effect of the `--runtime-dir` option
+on the other options' search paths: it is automatically set to the path where
+`vis_avs.dat` is located.
 
-```
+```console
 export WINEPREFIX="$HOME/.wine32"
 export WINEARCH=win32
-wineboot -i            
-winecfg
+wineboot --init
+# optional: xvfb-run winecfg
 ```
 
-```
+```console
 # then run your app with that prefix:
-WINEPREFIX="$HOME/.wine32 .\visdriver.exe generate-verification-data`
- --runtime-dir .\Plugins\`
- --vis-avs-dat .\vis_avs.dat`
- --vis-dll .\vis_avs.dll`
- --out-dll .\out_wave.dll`
- --preset .\tests\data\phase1\color_mod.avs`
- --wav .\Plugins\tests\data\electronic.wav`
- --out-dir .\tests\out\`
- --avi-out test.avi
- --width 1000 --height 600
+WINEPREFIX="$HOME/.wine32" wine .\visdriver.exe generate-verification-data \
+  --runtime-dir ".\Plugins\\" \
+  --vis-avs-dat ".\vis_avs.dat" \
+  --vis-dll ".\vis_avs.dll" \
+  --out-dll ".\out_wave.dll" \
+  --preset ".\tests\data\phase1\color_mod.avs" \
+  --wav ".\Plugins\tests\data\electronic.wav" \
+  --out-dir ".\tests\out\\" \
+  --avi-out test.avi \
+  --width 1000 --height 600
 ```
 
 ### CLI Output


### PR DESCRIPTION
## Summary
- expand the Ubuntu setup instructions to enable i386 packages and install the Wine components required for a 32-bit prefix
- document the need for CONFIG_IA32_EMULATION support and add guidance for preparing the Wine prefix in both README.md and AGENTS.md
- refresh the example commands so the 32-bit prefix workflow is consistent across project docs

## Testing
- `cmake -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build`
- `make -C build -j$(nproc) VERBOSE=1`


------
https://chatgpt.com/codex/tasks/task_e_68e0fb9227e0832cbb29c9464871eede