### PR TITLE
Update documentation and CI for consistent 32-bit Wine setup

### DIFF
--- a/.ci/ubuntu-packages.txt
+++ b/.ci/ubuntu-packages.txt
@@ -2,5 +2,8 @@ build-essential
 cmake
 ccache
 mingw-w64
+wine
 wine64
 wine32:i386
+winbind
+xvfb

--- a/.github/workflows/linux-mingw.yml
+++ b/.github/workflows/linux-mingw.yml
@@ -59,10 +59,10 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
+          sudo dpkg --add-architecture i386
           sudo apt-get update
           packages="$(grep -vE '^\s*(#|$)' .ci/ubuntu-packages.txt || true)"
           if [[ -n "${packages}" ]]; then
-            sudo dpkg --add-architecture i386; \
             sudo apt-get -o dir::cache::archives="${GITHUB_WORKSPACE}/${APT_CACHE_DIR}" \
               install --yes --no-install-recommends -V ${packages}
           else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,108 +1,82 @@
-
 # AGENTS.md
 
 ## Setup
 
 * Build with **CMake** and **MinGW**.
+* Ubuntu/Debian environments must enable multi-arch *before* refreshing the
+  package lists so that 32-bit Wine packages are available:
 
+  ```bash
+  sudo dpkg --add-architecture i386
+  sudo apt-get update
+  sudo apt-get install --yes --no-install-recommends \
+      build-essential cmake ccache mingw-w64 \
+      wine wine64 wine32:i386 winbind xvfb
+  ```
 
-* In Ubuntu environments enable multi-arch and install the `build-essential`, `cmake`, `ccache`, `mingw-w64`, `wine`, `wine64`, and `wine32:i386` packages, matching `.ci/ubuntu-packages.txt`.
-  Enable 32-bit packages before installing Wine:
+  The package list mirrors `.ci/ubuntu-packages.txt`.
 
-  Install them with:
+* If `wine --version` or `/usr/lib/i386-linux-gnu/glib-2.0/glib-compile-schemas`
+  reports `Exec format error`, the host kernel is missing
+  `CONFIG_IA32_EMULATION` and cannot execute 32-bit binaries. Use a kernel or
+  VM that supports 32-bit userspace before attempting to run visdriver.
+* Dependencies are vendored header-only or small C libraries; no additional
+  downloads are required beyond the system packages above.
 
-```bash
-sudo dpkg --add-architecture i386
-sudo apt-get update
-sudo apt-get install --yes \
-    build-essential cmake ccache mingw-w64 \
-    wine wine64 wine32:i386 winbind xvfb
-```
+### Build
 
-* If `wine --version` exits with `Exec format error`, the host kernel does not
-  have `CONFIG_IA32_EMULATION` enabled. Use a kernel/VM that supports 32-bit
-  binaries; Wine cannot run otherwise.
+* Configure via CMake using the MinGW toolchain file and build with GNU make:
 
-  A Linux host must support 32-bit userspace binaries (`CONFIG_IA32_EMULATION` on x86\_64). If `/usr/lib/i386-linux-gnu/glib-2.0/glib-compile-schemas --version`
-  exits with `Exec format error`, the kernel cannot execute 32-bit ELF binaries and a 32-bit Wine prefix will not start.
+  ```bash
+  cmake -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -S . -B build
+  make -C build -j"$(nproc)" VERBOSE=1
+  ```
 
-* Dependencies are vendored header-only or tiny C libs (no big external deps).
+  Copy the helper DLLs and test assets next to the resulting executable when
+  running integration tests:
 
-### Build 
-
-see `.github/workflows/linux-mingw.yml` for complete build instructions.
-
-the shorter version is as follows, but the above is the best source of truth:
-
-run 
-```
-cmake -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -S . -B build
-make -C build -j$(nproc) VERBOSE=1
-```
-
-to build in a ubuntu environment with the following packages
-
-```
-build-essential
-cmake
-ccache
-mingw-w64
-wine
-wine64
-wine32:i386
-winbind
-xvfb
-```
-
-copy the necessary dlls into the directory with the executable 
-```
-cp for_codex/dll/* build/
-cp -R for_codex/tests build/
-```
+  ```bash
+  cp for_codex/dll/* build/
+  cp -R for_codex/tests build/
+  ```
 
 ### Run
 
+* Initialise a dedicated 32-bit Wine prefix once per machine:
 
-visdriver.exe generate-verification-data --help
-Options:
-  --vis-dll <path>      Path to vis DLL (required)
-  --runtime-dir <dir>   Runtime directory (default: directory of vis DLL)
-  --vis-avs-dat <path>  Optional path to vis_avs.dat
-  --out-dll <path>      Optional output plug-in DLL
-  --preset <path>       Optional path to preset file
-  --wav <path>          Path to WAV input (required)
-  --width <pixels>      Output width (default: 640)
-  --height <pixels>     Output height (default: 480)
-  --fps <value>         Frames per second (default: 60)
-  --frames <count>      Number of frames to render (default: 121)
-  --out-dir <dir>       Output directory (required)
-  --avi-out <filename>  Optional AVI output filename
-  --png-step <value>    Interval between PNG dumps (default: 1)
-  --hash-mode <mode>    Hashing mode: pixels|rolling (default: pixels)
-  --help, -h            Show this help message
+  ```bash
+  export WINEARCH=win32
+  export WINEPREFIX="$HOME/.wine32"
+  wineboot -i
+  # Optional: DISPLAY must be available for winecfg
+  # winecfg
+  ```
 
-configure 32 bit wineprefix to run your app
-```
-export WINEPREFIX="$HOME/.wine32"
-export WINEARCH=win32
-wineboot --init
-# optional: xvfb-run winecfg
-wine --version
-wineboot -i
-winecfg&
-```
-then ensure the prefix is set to the environment variable before running
-  
-```
-cd build
-WINEPREFIX="$HOME/.wine32" wine visdriver.exe generate-verification-data --vis-dll ./vis_avs.dll --vis-avs-dat ./vis_avs.dat --runtime-dir ./ --wav ./tests/data/test.wav --preset ./tests/data/phase1/simple.avs --out-dir ./tests/golden/phase1/simple
-```
+* Keep `WINEPREFIX` set whenever running the tools. For example:
 
-If any Wine command reports `Exec format error`, run `uname -a` and verify that the host kernel supports 32-bit execution (look for `CONFIG_IA32_EMULATION=y`). Wine cannot launch 32-bit Windows binaries without that kernel feature; switch to an environment with 32-bit support before retrying.
+  ```bash
+  cd build
+  WINEPREFIX="$HOME/.wine32" wine ./visdriver.exe generate-verification-data \
+      --vis-dll ./vis_avs.dll \
+      --vis-avs-dat ./vis_avs.dat \
+      --runtime-dir ./ \
+      --wav ./tests/data/test.wav \
+      --preset ./tests/data/phase1/simple.avs \
+      --out-dir ./tests/golden/phase1/simple
+  ```
+
+* `visdriver.exe generate-verification-data --help` describes all CLI options.
+  Ensure `--vis-dll` and `--wav` point at valid Windows paths within the Wine
+  prefix or the current directory mapped by Wine.
+
+If any Wine command reports `Exec format error`, confirm the host kernel
+supports 32-bit execution before retrying.
 
 ---
 
-## Misc. Directives 
+## Misc. Directives
 
 * Use wide-char everywhere on Windows paths (`std::wstring`, `CreateFileW`, etc.).
 * Always `CreateDirectoryW` (recursive helper) before writing.
@@ -164,7 +138,7 @@ A new CLI function to produce deterministic goldens from `vis_avs.dll`.
 * `hashes/per_frame.csv` (frame index + sha256 of raw pixels)
 * `hashes/rolling_sha256.txt` (aggregate hash across all frames)
 * `manifest.json` (metadata of inputs/outputs, DLL, WAV, sizes, hashes)
-* optional: `*.avi` (uncompressed 32-bit BI\_RGB)
+* optional: `*.avi` (uncompressed 32-bit BI_RGB)
 
 ---
 
@@ -173,10 +147,10 @@ A new CLI function to produce deterministic goldens from `vis_avs.dll`.
 Codex must work incrementally. Each PR implements **one phase** only.
 
 1. **CLI skeleton**: parse args, print summary.
-2. **vis\_avs.dll load**: load DLL, create parent/child window.
+2. **vis_avs.dll load**: load DLL, create parent/child window.
 3. **WAV reader**: parse/resample 16-bit stereo PCM.
 4. **Dry render loop**: call Init/Render/Quit with zeroed buffers.
-5. **Waveform fill**: 576-sample window mapped to \[0..255].
+5. **Waveform fill**: 576-sample window mapped to [0..255].
 6. **Spectrum fill**: FFT 1024 samples → 576 bins.
 7. **Frame capture**: BitBlt to DIB, write PNGs.
 8. **Hashes**: per-frame + rolling SHA-256.
@@ -192,4 +166,3 @@ Codex must work incrementally. Each PR implements **one phase** only.
 * Subcommand compiles and runs with `--help`.
 * Produces logs/errors instead of crashing.
 * Deterministic outputs (PNG/Hash) identical on repeat runs.
-

--- a/README.md
+++ b/README.md
@@ -64,21 +64,19 @@ its page will list artifacts for download near the bottom.
 
 On a fresh Ubuntu 24.04 environment the MinGW toolchain and Wine runtime are
 not available by default. Install the packages that mirror our CI environment
-
-first. Enabling the `i386` architecture is required before the 32-bit Wine
-packages (`wine32:i386`) are visible to `apt`:
-
+first. Enable the `i386` architecture *before* refreshing the package lists so
+that the 32-bit Wine packages become visible to `apt`:
 
 ```console
 sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install -y \
+sudo apt-get install --yes --no-install-recommends \
     build-essential cmake ccache mingw-w64 \
     wine wine64 wine32:i386 winbind xvfb
 ```
 
-If the helper binary `/usr/lib/i386-linux-gnu/glib-2.0/glib-compile-schemas`
-exits with `Exec format error`, the host kernel cannot run 32-bit ELF binaries.
+If `wine --version` or `/usr/lib/i386-linux-gnu/glib-2.0/glib-compile-schemas`
+returns `Exec format error`, the host kernel cannot run 32-bit ELF binaries.
 Wine cannot create a 32-bit prefix in that configuration; use a machine with
 `CONFIG_IA32_EMULATION` enabled or a VM/container that provides 32-bit support.
 
@@ -88,15 +86,14 @@ Before building or running visdriver, create a dedicated 32-bit Wine prefix:
 export WINEARCH=win32
 export WINEPREFIX="$HOME/.wine32"
 wineboot -i
-winecfg&    # optional, requires an X11 server
+# Optional: requires an X11 server
+# winecfg
 ```
 
-> **Heads-up:** Wine requires Linux kernels with the `CONFIG_IA32_EMULATION`
-> option enabled to execute 32-bit binaries. If `wine --version` exits with
-> `Exec format error`, check `/proc/sys/abi/ia32_emulation`. When that file is
-> missing or contains `0`, the host kernel cannot execute 32-bit code and the
-> Wine runtime will not start. In that case use a different kernel or a virtual
-> machine that provides 32-bit compatibility.
+> **Heads-up:** `CONFIG_IA32_EMULATION` must be enabled in the Linux kernel to
+> execute 32-bit binaries. When `wine --version` or `/proc/sys/abi/ia32_emulation`
+> indicates the feature is disabled, switch to a kernel/VM with 32-bit support
+> before continuing.
 
 With the dependencies in place, configure and build using the MinGW toolchain
 file provided by this repository.
@@ -118,38 +115,35 @@ make -C build -j$(nproc) VERBOSE=1
 # How to Run
 
 After the build finishes copy the support DLLs into the build directory and
-initialise a 32-bit Wine prefix:
+export the Wine environment variables used throughout the examples below:
 ```console
 cp for_codex/dll/* build/
 cp -R for_codex/tests build/
-export WINEPREFIX="$HOME/.wine32"
 export WINEARCH=win32
-wineboot --init
+export WINEPREFIX="$HOME/.wine32"
 ```
-
-If you are on a headless machine, run `winecfg` via `xvfb-run winecfg` or skip
-it entirely; it is only required when you want to tweak Wine settings.
-
 
 Before running the executable make sure your Wine installation can launch
 32-bit binaries:
 
 ```console
-WINEPREFIX="$HOME/.wine32" WINEARCH=win32 wine --version
+WINEPREFIX="$HOME/.wine32" wine --version
 ```
 
 If this command fails with `Exec format error` your kernel is missing
 `CONFIG_IA32_EMULATION` support; rerun these steps on a host that can execute
 32-bit ELF binaries.
 
-With a working Wine install, create a fresh 32-bit prefix and configure it once:
+With a working Wine install, initialise the prefix once per machine:
 
 ```console
-export WINEPREFIX="$HOME/.wine32"
-export WINEARCH=win32
 wineboot -i
-winecfg&  # optional tweaks
+# Optional: requires an X11 server
+# winecfg
 ```
+
+If you are on a headless machine, run `winecfg` via `xvfb-run winecfg` or skip
+it entirely; it is only required when you want to tweak Wine settings.
 
 Let **visdriver** tell you what it needs:
 ```console
@@ -221,14 +215,14 @@ Take note of the effect of the `--runtime-dir` option on the other option search
 the directory that holds `vis_avs.dat` so you will rarely want to omit it.
 
 ```console
-export WINEPREFIX="$HOME/.wine32"
-export WINEARCH=win32
-wineboot --init
-# optional: xvfb-run winecfg
+# If the prefix has not been initialised yet:
+WINEPREFIX="$HOME/.wine32" wineboot -i
+# Optional (requires an X11 server):
+# xvfb-run winecfg
 ```
 
-Before running from the MinGW build tree, copy the support DLLs and test data that
-the Codex harness provides:
+Before running from the MinGW build tree, copy the support DLLs and test data
+that the Codex harness provides:
 
 ```console
 cp for_codex/dll/* build/


### PR DESCRIPTION
## Summary
- align AGENTS.md and README instructions with the working 32-bit Wine prefix procedure
- add required Wine-related packages to .ci/ubuntu-packages.txt to match the documented environment
- adjust the Linux MinGW workflow to enable i386 before running apt update

## Testing
- not run (documentation and workflow configuration changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e10c3a91e0832c833d9ae340f5c85b