### PR TITLE
Document Ubuntu 24.04 wine package availability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,11 @@
 
   The package list mirrors `.ci/ubuntu-packages.txt`.
 
+  Ubuntu 24.04 only ships the `wine` meta package in the default
+  repositories. If older docs mention `wine-stable`, add the WineHQ PPA
+  before installing or substitute the `wine` package name to keep the
+  dependency list working out-of-the-box.
+
 * If `wine --version` or `/usr/lib/i386-linux-gnu/glib-2.0/glib-compile-schemas`
   reports `Exec format error`, the host kernel is missing
   `CONFIG_IA32_EMULATION` and cannot execute 32-bit binaries. Use a kernel or

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ sudo apt-get install --yes --no-install-recommends \
     wine wine64 wine32:i386 winbind xvfb
 ```
 
+Ubuntu 24.04 only ships the `wine` meta package in the default repositories.
+If you follow older instructions that reference `wine-stable`, add the
+WineHQ repository first or switch the package name back to `wine` before
+running `apt-get install` to avoid resolution failures.
+
 If `wine --version` or `/usr/lib/i386-linux-gnu/glib-2.0/glib-compile-schemas`
 returns `Exec format error`, the host kernel cannot run 32-bit ELF binaries.
 Wine cannot create a 32-bit prefix in that configuration; use a machine with


### PR DESCRIPTION
## Summary
- document that Ubuntu 24.04 only ships the wine meta package by default
- point readers at the WineHQ repository or the stock wine meta package instead of wine-stable

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2a1df3600832c9baf7498bef2a709